### PR TITLE
Replace nv_root finding via frames to using the first joint

### DIFF
--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -165,9 +165,8 @@ static inline void toMsg(
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(a.size()));
   }
-  const std::size_t root_joint_id = model.frames[1].parent;
-  const std::size_t nv_root = model.joints[root_joint_id].idx_q() == 0
-                                  ? model.joints[root_joint_id].nv()
+  const std::size_t nv_root = model.joints[1].idx_q() == 0
+                                  ? model.joints[1].nv()
                                   : 0;
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints) && tau.size() != 0) {
@@ -464,9 +463,8 @@ fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(v.size()));
   }
-  const std::size_t root_joint_id = model.frames[1].parent;
-  const std::size_t nv_root = model.joints[root_joint_id].idx_q() == 0
-                                  ? model.joints[root_joint_id].nv()
+  const std::size_t nv_root = model.joints[1].idx_q() == 0
+                                  ? model.joints[1].nv()
                                   : 0;
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints)) {


### PR DESCRIPTION
When using crocoddyl_msgs with a custom URDF, the current method of finding the root joint by always selecting `frames[1].parent` does not work.

The change here is always using the second joint, i.e. `model.joints[1]`. This has fixed the issue for me, but I'm aware this is quite an important change that we may want consensus on. 