### PR TITLE
Using ROS to print starting message and fixed bug when using reduced models

### DIFF
--- a/include/crocoddyl_msgs/solver_statistics_publisher.h
+++ b/include/crocoddyl_msgs/solver_statistics_publisher.h
@@ -31,12 +31,13 @@ class SolverStatisticsRosPublisher {
   SolverStatisticsRosPublisher(const std::string &topic = "/crocoddyl/solver_statistics")
       : node_("solver_statistics_publisher"),
         pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverStatistics>(topic, 1)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing SolverStatistics messages on " << topic);
 #else
   SolverStatisticsRosPublisher(const std::string &topic = "/crocoddyl/solver_statistics") {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
+    ROS_INFO_STREAM("Publishing SolverStatistics messages on " << topic);
 #endif
-    std::cout << "Publish SolverStatistics messages on " << topic << std::endl;
   }
   ~SolverStatisticsRosPublisher() = default;
 

--- a/include/crocoddyl_msgs/solver_statistics_subscriber.h
+++ b/include/crocoddyl_msgs/solver_statistics_subscriber.h
@@ -46,6 +46,7 @@ class SolverStatisticsRosSubscriber {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing SolverStatistics messages on " << topic);
 #else
   SolverStatisticsRosSubscriber(const std::string &topic = "/crocoddyl/solver_statistics")
       : spinner_(2), has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
@@ -53,8 +54,8 @@ class SolverStatisticsRosSubscriber {
     sub_ = n.subscribe<SolverStatistics>(topic, 1, &SolverStatisticsRosSubscriber::callback, this,
                                          ros::TransportHints().tcpNoDelay());
     spinner_.start();
+    ROS_INFO_STREAM("Subscribing SolverStatistics messages on " << topic);
 #endif
-    std::cout << "Subscribe to SolverStatistics messages on " << topic << std::endl;
   }
   ~SolverStatisticsRosSubscriber() = default;
 

--- a/include/crocoddyl_msgs/solver_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/solver_trajectory_publisher.h
@@ -37,14 +37,15 @@ class SolverTrajectoryRosPublisher {
                                const std::string &frame = "odom")
       : node_("solver_trajectory_publisher"),
         pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverTrajectory>(topic, 1)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing SolverTrajectory messages on " << topic <<  " (frame: " << frame << ")");
 #else
   SolverTrajectoryRosPublisher(const std::string &topic = "/crocoddyl/solver_trajectory",
                                const std::string &frame = "odom") {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
+    ROS_INFO_STREAM("Publishing SolverTrajectory messages on " << topic <<  " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
-    std::cout << "Publish SolverTrajectory messages on " << topic << " (frame: " << frame << ")" << std::endl;
   }
   ~SolverTrajectoryRosPublisher() = default;
 

--- a/include/crocoddyl_msgs/solver_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/solver_trajectory_subscriber.h
@@ -50,6 +50,7 @@ class SolverTrajectoryRosSubscriber {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing SolverTrajectory messages on " << topic);
 #else
   SolverTrajectoryRosSubscriber(const std::string &topic = "/crocoddyl/solver_trajectory")
       : spinner_(2), has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
@@ -57,8 +58,8 @@ class SolverTrajectoryRosSubscriber {
     sub_ = n.subscribe<SolverTrajectory>(topic, 1, &SolverTrajectoryRosSubscriber::callback, this,
                                          ros::TransportHints().tcpNoDelay());
     spinner_.start();
+    ROS_INFO_STREAM("Subscribing SolverTrajectory messages on " << topic);
 #endif
-    std::cout << "Subscribe to SolverTrajectory messages on " << topic << std::endl;
   }
   ~SolverTrajectoryRosSubscriber() = default;
 

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -39,15 +39,16 @@ class WholeBodyStateRosPublisher {
         data_(model),
         odom_frame_(frame),
         a_(Eigen::VectorXd::Zero(model.nv)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing WholeBodyState messages on " << topic <<  " (frame: " << frame << ")");
 #else
   WholeBodyStateRosPublisher(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
                              const std::string &frame = "odom")
       : model_(model), data_(model), odom_frame_(frame), a_(Eigen::VectorXd::Zero(model.nv)) {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
+    ROS_INFO_STREAM("Publishing WholeBodyState messages on " << topic <<  " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
-    std::cout << "Publish WholeBodyState messages on " << topic << " (frame: " << frame << ")" << std::endl;
   }
   ~WholeBodyStateRosPublisher() = default;
 

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -56,6 +56,7 @@ class WholeBodyStateRosSubscriber {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing WholeBodyState messages on " << topic);
 #else
   WholeBodyStateRosSubscriber(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
                               const std::string &frame = "odom")
@@ -74,6 +75,7 @@ class WholeBodyStateRosSubscriber {
     sub_ = n.subscribe<WholeBodyState>(topic, 1, &WholeBodyStateRosSubscriber::callback, this,
                                        ros::TransportHints().tcpNoDelay());
     spinner_.start();
+    ROS_INFO_STREAM("Subscribing WholeBodyState messages on " << topic);
 #endif
     const std::size_t root_joint_id = model.frames[1].parent;
     const std::size_t nv_root = model.joints[root_joint_id].idx_q() == 0 ? model.joints[root_joint_id].nv() : 0;
@@ -82,7 +84,6 @@ class WholeBodyStateRosSubscriber {
     v_.setZero();
     a_.setZero();
     tau_ = Eigen::VectorXd::Zero(njoints);
-    std::cout << "Subscribe to WholeBodyState messages on " << topic << std::endl;
   }
   ~WholeBodyStateRosSubscriber() = default;
 

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -77,9 +77,8 @@ class WholeBodyStateRosSubscriber {
     spinner_.start();
     ROS_INFO_STREAM("Subscribing WholeBodyState messages on " << topic);
 #endif
-    const std::size_t root_joint_id = model.frames[1].parent;
-    const std::size_t nv_root = model.joints[root_joint_id].idx_q() == 0 ? model.joints[root_joint_id].nv() : 0;
-    const std::size_t njoints = model.nv - nv_root;
+    const std::size_t root_joint_id = model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
+    const std::size_t njoints = model.nv - model.joints[root_joint_id].nv();
     q_.setZero();
     v_.setZero();
     a_.setZero();

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -41,6 +41,7 @@ class WholeBodyTrajectoryRosPublisher {
         data_(model),
         odom_frame_(frame),
         a_null_(model.nv) {
+    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing WholeBodyTrajectory messages on " << topic <<  " (frame: " << frame << ")");
 #else
   WholeBodyTrajectoryRosPublisher(pinocchio::Model &model,
                                   const std::string &topic = "/crocoddyl/whole_body_trajectory",
@@ -48,10 +49,10 @@ class WholeBodyTrajectoryRosPublisher {
       : model_(model), data_(model), odom_frame_(frame), a_null_(model.nv) {
     ros::NodeHandle n;
     pub_.init(n, topic, queue);
+    ROS_INFO_STREAM("Publishing WholeBodyTrajectory messages on " << topic <<  " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
     a_null_.setZero();
-    std::cout << "Publish WholeBodyTrajectory messages on " << topic << " (frame: " << frame << ")" << std::endl;
   }
   ~WholeBodyTrajectoryRosPublisher() = default;
 

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -74,10 +74,9 @@ class WholeBodyTrajectoryRosSubscriber {
     ROS_INFO_STREAM("Subscribing WholeBodyTrajectory messages on " << topic);
 #endif
     a_null_.setZero();
-    const std::size_t root_joint_id = model_.frames[1].parent;
-    const std::size_t nv_root = model_.joints[root_joint_id].idx_q() == 0 ? model_.joints[root_joint_id].nv() : 0;
+    const std::size_t root_joint_id = model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
     nx_ = model_.nq + model_.nv;
-    nu_ = model_.nv - nv_root;
+    nu_ = model.nv - model.joints[root_joint_id].nv();
   }
   ~WholeBodyTrajectoryRosSubscriber() = default;
 

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -54,6 +54,7 @@ class WholeBodyTrajectoryRosSubscriber {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
+    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing WholeBodyTrajectory messages on " << topic);
 #else
   WholeBodyTrajectoryRosSubscriber(pinocchio::Model &model,
                                    const std::string &topic = "/crocoddyl/whole_body_trajectory",
@@ -70,13 +71,13 @@ class WholeBodyTrajectoryRosSubscriber {
     sub_ = n.subscribe<WholeBodyTrajectory>(topic, 1, &WholeBodyTrajectoryRosSubscriber::callback, this,
                                             ros::TransportHints().tcpNoDelay());
     spinner_.start();
+    ROS_INFO_STREAM("Subscribing WholeBodyTrajectory messages on " << topic);
 #endif
     a_null_.setZero();
     const std::size_t root_joint_id = model_.frames[1].parent;
     const std::size_t nv_root = model_.joints[root_joint_id].idx_q() == 0 ? model_.joints[root_joint_id].nv() : 0;
     nx_ = model_.nq + model_.nv;
     nu_ = model_.nv - nv_root;
-    std::cout << "Subscribe to WholeBodyTrajectory messages on " << topic << std::endl;
   }
   ~WholeBodyTrajectoryRosSubscriber() = default;
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>crocoddyl_msgs</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
     Message structures needed to interact with Crocoddyl solvers, inputs and outputs. Compatibility with ROS1 and ROS2.
   </description>


### PR DESCRIPTION
This PR proposes:
 - Use ROS to log messages
 - Compute root_joint_id via `root_joint`

The second point is critical as the current method leads to bad results when reducing the models (to lock joints).

Fyi @james-p-foster  and @Sergim96 