### PR TITLE
Introducing locked joints in publishers and subscribers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 # Set up project properties
 set(PROJECT_NAME crocoddyl_msgs)
 set(PROJECT_DESCRIPTION "Crocoddyl ROS messages")
+set(PROJECT_VERSION 1.1.0)
 
 # Print initial message
 message(STATUS "${PROJECT_DESCRIPTION}, version ${PROJECT_VERSION}")

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -80,7 +80,7 @@ typedef whole_body_state_msgs::ContactState ContactState;
  * @param return  Root joint Id
  */
 template <int Options, template <typename, int> class JointCollectionTpl>
-static inline std::size_t get_root_joint_id(
+static inline std::size_t getRootJointId(
     const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model) {
   return model.existJointName("root_joint")
              ? model.getJointId("root_joint")
@@ -211,7 +211,7 @@ static inline void toMsg(
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(a.size()));
   }
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   const std::size_t nv_root = model.joints[root_joint_id].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints) && tau.size() != 0) {
@@ -510,7 +510,7 @@ fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(v.size()));
   }
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   const std::size_t nv_root = model.joints[root_joint_id].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints)) {
@@ -649,7 +649,7 @@ static inline void fromReduced(
     const Eigen::Ref<const Eigen::VectorXd> &tau_in,
     const Eigen::Ref<const Eigen::VectorXd> &qref,
     const std::vector<pinocchio::JointIndex> &locked_joint_ids) {
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   const std::size_t nq_root = model.joints[root_joint_id].nq();
   const std::size_t nv_root = model.joints[root_joint_id].nv();
   if (q_out.size() != model.nq) {
@@ -728,7 +728,7 @@ toReduced(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
           const Eigen::Ref<const Eigen::VectorXd> &q_in,
           const Eigen::Ref<const Eigen::VectorXd> &v_in,
           const Eigen::Ref<const Eigen::VectorXd> &tau_in) {
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   const std::size_t nq_root = model.joints[root_joint_id].nq();
   const std::size_t nv_root = model.joints[root_joint_id].nv();
   if (q_out.size() != reduced_model.nq) {
@@ -789,7 +789,7 @@ fromReduced_return(
     const Eigen::Ref<const Eigen::VectorXd> &tau_in,
     const Eigen::Ref<const Eigen::VectorXd> &qref,
     const std::vector<pinocchio::JointIndex> &locked_joint_ids) {
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   Eigen::VectorXd q_out = Eigen::VectorXd::Zero(model.nq);
   Eigen::VectorXd v_out = Eigen::VectorXd::Zero(model.nv);
   Eigen::VectorXd tau_out =
@@ -808,7 +808,7 @@ toReduced_return(
     const Eigen::Ref<const Eigen::VectorXd> &q_in,
     const Eigen::Ref<const Eigen::VectorXd> &v_in,
     const Eigen::Ref<const Eigen::VectorXd> &tau_in) {
-  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t root_joint_id = getRootJointId(model);
   Eigen::VectorXd q_out = Eigen::VectorXd::Zero(reduced_model.nq);
   Eigen::VectorXd v_out = Eigen::VectorXd::Zero(reduced_model.nv);
   Eigen::VectorXd tau_out = Eigen::VectorXd::Zero(

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -46,6 +46,8 @@
 
 namespace crocoddyl_msgs {
 
+static std::vector<std::string> DEFAULT_VECTOR;
+
 enum ControlType { EFFORT = 0, ACCELERATION_CONTACTFORCE };
 
 enum ControlParametrization { POLYZERO = 0, POLYONE, POLYTWO };

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -28,17 +28,17 @@
 #include <pinocchio/bindings/python/pybind11-all.hpp>
 
 #ifdef ROS2
-#include "crocoddyl_msgs/msg/time_interval.hpp"
 #include "crocoddyl_msgs/msg/control.hpp"
 #include "crocoddyl_msgs/msg/feedback_gain.hpp"
 #include "crocoddyl_msgs/msg/state.hpp"
+#include "crocoddyl_msgs/msg/time_interval.hpp"
 #include <whole_body_state_msgs/msg/whole_body_state.hpp>
 #include <whole_body_state_msgs/msg/whole_body_trajectory.hpp>
 #else
-#include "crocoddyl_msgs/TimeInterval.h"
 #include "crocoddyl_msgs/Control.h"
 #include "crocoddyl_msgs/FeedbackGain.h"
 #include "crocoddyl_msgs/State.h"
+#include "crocoddyl_msgs/TimeInterval.h"
 #include <whole_body_state_msgs/WholeBodyState.h>
 #include <whole_body_state_msgs/WholeBodyTrajectory.h>
 #endif
@@ -78,13 +78,14 @@ typedef whole_body_state_msgs::ContactState ContactState;
  * @param[out] msg  ROS message that contains the feedback gain
  * @param[in] K     Feedback gain (size nu * nx)
  */
-static inline void toMsg(FeedbackGain &msg, const Eigen::Ref<const Eigen::MatrixXd> &K) {
+static inline void toMsg(FeedbackGain &msg,
+                         const Eigen::Ref<const Eigen::MatrixXd> &K) {
   msg.nu = static_cast<uint32_t>(K.rows());
   msg.nx = static_cast<uint32_t>(K.cols());
   msg.data.resize(msg.nx * msg.nu);
   for (uint32_t i = 0; i < msg.nu; ++i) {
     for (uint32_t j = 0; j < msg.nx; ++j) {
-      msg.data[i * msg.nx + j] = K(i, j);  // store in row-major order
+      msg.data[i * msg.nx + j] = K(i, j); // store in row-major order
     }
   }
 }
@@ -119,8 +120,10 @@ static inline void toMsg(State &msg, const Eigen::Ref<const Eigen::VectorXd> &x,
  * @param[in] type             Control type
  * @param[in] parametrization  Control parametrization
  */
-static inline void toMsg(Control &msg, const Eigen::Ref<const Eigen::VectorXd> &u,
-                         const Eigen::Ref<const Eigen::MatrixXd> &K, const ControlType type,
+static inline void toMsg(Control &msg,
+                         const Eigen::Ref<const Eigen::VectorXd> &u,
+                         const Eigen::Ref<const Eigen::MatrixXd> &K,
+                         const ControlType type,
                          const ControlParametrization parametrization) {
   msg.u.resize(u.size());
   for (int i = 0; i < u.size(); ++i) {
@@ -128,23 +131,23 @@ static inline void toMsg(Control &msg, const Eigen::Ref<const Eigen::VectorXd> &
   }
   toMsg(msg.gain, K);
   switch (type) {
-    case ControlType::EFFORT:
-      msg.input = crocoddyl_msgs::Control::EFFORT;
-      break;
-    case ControlType::ACCELERATION_CONTACTFORCE:
-      msg.input = crocoddyl_msgs::Control::ACCELERATION_CONTACTFORCE;
-      break;
+  case ControlType::EFFORT:
+    msg.input = crocoddyl_msgs::Control::EFFORT;
+    break;
+  case ControlType::ACCELERATION_CONTACTFORCE:
+    msg.input = crocoddyl_msgs::Control::ACCELERATION_CONTACTFORCE;
+    break;
   }
   switch (parametrization) {
-    case ControlParametrization::POLYZERO:
-      msg.parametrization = crocoddyl_msgs::Control::POLYZERO;
-      break;
-    case ControlParametrization::POLYONE:
-      msg.parametrization = crocoddyl_msgs::Control::POLYONE;
-      break;
-    case ControlParametrization::POLYTWO:
-      msg.parametrization = crocoddyl_msgs::Control::POLYTWO;
-      break;
+  case ControlParametrization::POLYZERO:
+    msg.parametrization = crocoddyl_msgs::Control::POLYZERO;
+    break;
+  case ControlParametrization::POLYONE:
+    msg.parametrization = crocoddyl_msgs::Control::POLYONE;
+    break;
+  case ControlParametrization::POLYTWO:
+    msg.parametrization = crocoddyl_msgs::Control::POLYTWO;
+    break;
   }
 }
 
@@ -165,40 +168,53 @@ static inline void toMsg(Control &msg, const Eigen::Ref<const Eigen::VectorXd> &
  * @param s[in]      Contact surface and friction coefficient
  */
 template <int Options, template <typename, int> class JointCollectionTpl>
-static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
-                         pinocchio::DataTpl<double, Options, JointCollectionTpl> &data, WholeBodyState &msg,
-                         const double t, const Eigen::Ref<const Eigen::VectorXd> &q,
-                         const Eigen::Ref<const Eigen::VectorXd> &v, const Eigen::Ref<const Eigen::VectorXd> &a,
-                         const Eigen::Ref<const Eigen::VectorXd> &tau, const std::map<std::string, pinocchio::SE3> &p,
-                         const std::map<std::string, pinocchio::Motion> &pd,
-                         const std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>> &f,
-                         const std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
+static inline void toMsg(
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+    pinocchio::DataTpl<double, Options, JointCollectionTpl> &data,
+    WholeBodyState &msg, const double t,
+    const Eigen::Ref<const Eigen::VectorXd> &q,
+    const Eigen::Ref<const Eigen::VectorXd> &v,
+    const Eigen::Ref<const Eigen::VectorXd> &a,
+    const Eigen::Ref<const Eigen::VectorXd> &tau,
+    const std::map<std::string, pinocchio::SE3> &p,
+    const std::map<std::string, pinocchio::Motion> &pd,
+    const std::map<std::string,
+                   std::tuple<pinocchio::Force, ContactType, ContactStatus>> &f,
+    const std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
   if (q.size() != model.nq) {
-    throw std::invalid_argument("Expected q to be " + std::to_string(model.nq) + " but received " +
-                                std::to_string(q.size()));
+    throw std::invalid_argument("Expected q to be " + std::to_string(model.nq) +
+                                " but received " + std::to_string(q.size()));
   }
   if (v.size() != model.nv) {
-    throw std::invalid_argument("Expected v to be " + std::to_string(model.nv) + " but received " +
-                                std::to_string(v.size()));
+    throw std::invalid_argument("Expected v to be " + std::to_string(model.nv) +
+                                " but received " + std::to_string(v.size()));
   }
   if (a.size() != model.nv) {
-    throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) + " but received " +
-                                std::to_string(a.size()));
+    throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
+                                " but received " + std::to_string(a.size()));
   }
-  const std::size_t nv_root = model.joints[(model.existJointName("root_joint") ? model.getJointId("root_joint") : 0)].nv();
+  const std::size_t nv_root = model
+                                  .joints[(model.existJointName("root_joint")
+                                               ? model.getJointId("root_joint")
+                                               : 0)]
+                                  .nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints) && tau.size() != 0) {
-    throw std::invalid_argument("Expected tau to be 0 or " + std::to_string(njoints) + " but received " +
+    throw std::invalid_argument("Expected tau to be 0 or " +
+                                std::to_string(njoints) + " but received " +
                                 std::to_string(tau.size()));
   }
   if (p.size() != pd.size()) {
-    throw std::invalid_argument("Dimension of contact pose and velocity does not match.");
+    throw std::invalid_argument(
+        "Dimension of contact pose and velocity does not match.");
   }
   if (p.size() != f.size()) {
-    throw std::invalid_argument("Dimension of contact pose and force does not match.");
+    throw std::invalid_argument(
+        "Dimension of contact pose and force does not match.");
   }
   if (p.size() != s.size()) {
-    throw std::invalid_argument("Dimension of contact pose and surface does not match.");
+    throw std::invalid_argument(
+        "Dimension of contact pose and surface does not match.");
   }
   // Filling the time information
   msg.time = t;
@@ -218,7 +234,7 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
   msg.centroidal.com_velocity.y = data.vcom[0].y();
   msg.centroidal.com_velocity.z = data.vcom[0].z();
   // Base
-  if (nv_root == 6) {  // TODO(cmastalli): handle other root joints
+  if (nv_root == 6) { // TODO(cmastalli): handle other root joints
     msg.centroidal.base_orientation.x = q(3);
     msg.centroidal.base_orientation.y = q(4);
     msg.centroidal.base_orientation.z = q(5);
@@ -227,19 +243,22 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
     msg.centroidal.base_angular_velocity.y = v(4);
     msg.centroidal.base_angular_velocity.z = v(5);
   } else if (nv_root != 0) {
-    std::cerr << "Warning: toMsg conversion does not yet support root joints "
-                 "different to a floating base. We cannot publish base information."
-              << std::endl;
+    std::cerr
+        << "Warning: toMsg conversion does not yet support root joints "
+           "different to a floating base. We cannot publish base information."
+        << std::endl;
   }
   // Momenta
-  const pinocchio::Force &momenta = pinocchio::computeCentroidalMomentum(model, data);
+  const pinocchio::Force &momenta =
+      pinocchio::computeCentroidalMomentum(model, data);
   msg.centroidal.momenta.linear.x = momenta.linear().x();
   msg.centroidal.momenta.linear.y = momenta.linear().y();
   msg.centroidal.momenta.linear.z = momenta.linear().z();
   msg.centroidal.momenta.angular.x = momenta.angular().x();
   msg.centroidal.momenta.angular.y = momenta.angular().y();
   msg.centroidal.momenta.angular.z = momenta.angular().z();
-  const pinocchio::Force &momenta_rate = pinocchio::computeCentroidalMomentumTimeVariation(model, data);
+  const pinocchio::Force &momenta_rate =
+      pinocchio::computeCentroidalMomentumTimeVariation(model, data);
   msg.centroidal.momenta_rate.linear.x = momenta_rate.linear().x();
   msg.centroidal.momenta_rate.linear.y = momenta_rate.linear().y();
   msg.centroidal.momenta_rate.linear.z = momenta_rate.linear().z();
@@ -265,16 +284,19 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
     if (static_cast<int>(frame_id) > model.nframes) {
       throw std::runtime_error("Frame '" + name + "' not found.");
     }
-    std::map<std::string, pinocchio::Motion>::const_iterator pd_it = pd.find(name);
+    std::map<std::string, pinocchio::Motion>::const_iterator pd_it =
+        pd.find(name);
     if (pd_it == pd.end()) {
       throw std::runtime_error("Frame '" + name + "' not found in pd.");
     }
-    std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>>::const_iterator f_it =
+    std::map<std::string, std::tuple<pinocchio::Force, ContactType,
+                                     ContactStatus>>::const_iterator f_it =
         f.find(name);
     if (f_it == f.end()) {
       throw std::runtime_error("Frame '" + name + "' not found in f.");
     }
-    std::map<std::string, std::pair<Eigen::Vector3d, double>>::const_iterator s_it = s.find(name);
+    std::map<std::string, std::pair<Eigen::Vector3d, double>>::const_iterator
+        s_it = s.find(name);
     if (s_it == s.end()) {
       throw std::runtime_error("Frame '" + name + "' not found in s.");
     }
@@ -306,31 +328,32 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
   }
   i = 0;
   for (const auto &f_item : f) {
-    const std::tuple<pinocchio::Force, ContactType, ContactStatus> &force = f_item.second;
+    const std::tuple<pinocchio::Force, ContactType, ContactStatus> &force =
+        f_item.second;
     const pinocchio::Force &wrench = std::get<0>(force);
     const ContactType type = std::get<1>(force);
     switch (type) {
-      case ContactType::LOCOMOTION:
-        msg.contacts[i].type = ContactState::LOCOMOTION;
-        break;
-      case ContactType::MANIPULATION:
-        msg.contacts[i].type = ContactState::MANIPULATION;
-        break;
+    case ContactType::LOCOMOTION:
+      msg.contacts[i].type = ContactState::LOCOMOTION;
+      break;
+    case ContactType::MANIPULATION:
+      msg.contacts[i].type = ContactState::MANIPULATION;
+      break;
     }
     const ContactStatus status = std::get<2>(force);
     switch (status) {
-      case ContactStatus::UNKNOWN:
-        msg.contacts[i].status = ContactState::UNKNOWN;
-        break;
-      case ContactStatus::SEPARATION:
-        msg.contacts[i].status = ContactState::INACTIVE;
-        break;
-      case ContactStatus::STICKING:
-        msg.contacts[i].status = ContactState::ACTIVE;
-        break;
-      case ContactStatus::SLIPPING:
-        msg.contacts[i].status = ContactState::SLIPPING;
-        break;
+    case ContactStatus::UNKNOWN:
+      msg.contacts[i].status = ContactState::UNKNOWN;
+      break;
+    case ContactStatus::SEPARATION:
+      msg.contacts[i].status = ContactState::INACTIVE;
+      break;
+    case ContactStatus::STICKING:
+      msg.contacts[i].status = ContactState::ACTIVE;
+      break;
+    case ContactStatus::SLIPPING:
+      msg.contacts[i].status = ContactState::SLIPPING;
+      break;
     }
     msg.contacts[i].wrench.force.x = wrench.linear().x();
     msg.contacts[i].wrench.force.y = wrench.linear().y();
@@ -359,15 +382,16 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
  * @param[in] msg  ROS message that contains the feedback gain
  * @param[out] K   Feedback gain (size nu * nx)
  */
-static inline void fromMsg(const FeedbackGain &msg, Eigen::Ref<Eigen::MatrixXd> K) {
+static inline void fromMsg(const FeedbackGain &msg,
+                           Eigen::Ref<Eigen::MatrixXd> K) {
   if (K.rows() != msg.nu || K.cols() != msg.nx) {
-    throw std::invalid_argument("The dimensions of K need to be: (" + std::to_string(msg.nu) + ", " +
+    throw std::invalid_argument("The dimensions of K need to be: (" +
+                                std::to_string(msg.nu) + ", " +
                                 std::to_string(msg.nx) + ").");
   }
   if (msg.data.size() != msg.nu * msg.nx) {
-    throw std::invalid_argument(
-        "Message incorrect - size of data does not "
-        "match given dimensions (nu,nx)");
+    throw std::invalid_argument("Message incorrect - size of data does not "
+                                "match given dimensions (nu,nx)");
   }
 
   for (std::size_t i = 0; i < msg.nu; ++i) {
@@ -384,14 +408,17 @@ static inline void fromMsg(const FeedbackGain &msg, Eigen::Ref<Eigen::MatrixXd> 
  * @param[out] x   State at the beginning of the interval
  * @param[out] dx  State's rate of change during the interval
  */
-static inline void fromMsg(const State &msg, Eigen::Ref<Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> dx) {
+static inline void fromMsg(const State &msg, Eigen::Ref<Eigen::VectorXd> x,
+                           Eigen::Ref<Eigen::VectorXd> dx) {
   if (static_cast<std::size_t>(x.size()) != msg.x.size()) {
-    throw std::invalid_argument("Expected x to be " + std::to_string(msg.x.size()) + " but received " +
-                                std::to_string(x.size()));
+    throw std::invalid_argument("Expected x to be " +
+                                std::to_string(msg.x.size()) +
+                                " but received " + std::to_string(x.size()));
   }
   if (static_cast<std::size_t>(dx.size()) != msg.dx.size()) {
-    throw std::invalid_argument("Expected dx to be " + std::to_string(msg.dx.size()) + " but received " +
-                                std::to_string(dx.size()));
+    throw std::invalid_argument("Expected dx to be " +
+                                std::to_string(msg.dx.size()) +
+                                " but received " + std::to_string(dx.size()));
   }
   for (std::size_t i = 0; i < msg.x.size(); ++i) {
     x(i) = msg.x[i];
@@ -411,11 +438,13 @@ static inline void fromMsg(const State &msg, Eigen::Ref<Eigen::VectorXd> x, Eige
  * @param[out] type             Control type
  * @param[out] parametrization  Control parametrization
  */
-static inline void fromMsg(const Control &msg, Eigen::Ref<Eigen::VectorXd> u, Eigen::Ref<Eigen::MatrixXd> K,
-                           ControlType &type, ControlParametrization &parametrization) {
+static inline void fromMsg(const Control &msg, Eigen::Ref<Eigen::VectorXd> u,
+                           Eigen::Ref<Eigen::MatrixXd> K, ControlType &type,
+                           ControlParametrization &parametrization) {
   if (static_cast<std::size_t>(u.size()) != msg.u.size()) {
-    throw std::invalid_argument("Expected u to be " + std::to_string(msg.u.size()) + " but received " +
-                                std::to_string(u.size()));
+    throw std::invalid_argument("Expected u to be " +
+                                std::to_string(msg.u.size()) +
+                                " but received " + std::to_string(u.size()));
   }
   for (std::size_t i = 0; i < msg.u.size(); ++i) {
     u(i) = msg.u[i];
@@ -443,34 +472,45 @@ static inline void fromMsg(const Control &msg, Eigen::Ref<Eigen::VectorXd> u, Ei
  * @param s[out]     Contact surface and friction coefficient
  */
 template <int Options, template <typename, int> class JointCollectionTpl>
-static inline void fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
-                           pinocchio::DataTpl<double, Options, JointCollectionTpl> &data, const WholeBodyState &msg,
-                           double &t, Eigen::Ref<Eigen::VectorXd> q, Eigen::Ref<Eigen::VectorXd> v,
-                           Eigen::Ref<Eigen::VectorXd> a, Eigen::Ref<Eigen::VectorXd> tau,
-                           std::map<std::string, pinocchio::SE3> &p, std::map<std::string, pinocchio::Motion> &pd,
-                           std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>> &f,
-                           std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
+static inline void
+fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+        pinocchio::DataTpl<double, Options, JointCollectionTpl> &data,
+        const WholeBodyState &msg, double &t, Eigen::Ref<Eigen::VectorXd> q,
+        Eigen::Ref<Eigen::VectorXd> v, Eigen::Ref<Eigen::VectorXd> a,
+        Eigen::Ref<Eigen::VectorXd> tau,
+        std::map<std::string, pinocchio::SE3> &p,
+        std::map<std::string, pinocchio::Motion> &pd,
+        std::map<std::string,
+                 std::tuple<pinocchio::Force, ContactType, ContactStatus>> &f,
+        std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
   if (q.size() != model.nq) {
-    throw std::invalid_argument("Expected q to be " + std::to_string(model.nq) + " but received " +
-                                std::to_string(q.size()));
+    throw std::invalid_argument("Expected q to be " + std::to_string(model.nq) +
+                                " but received " + std::to_string(q.size()));
   }
   if (v.size() != model.nv) {
-    throw std::invalid_argument("Expected v to be " + std::to_string(model.nv) + " but received " +
-                                std::to_string(v.size()));
+    throw std::invalid_argument("Expected v to be " + std::to_string(model.nv) +
+                                " but received " + std::to_string(v.size()));
   }
   if (a.size() != model.nv) {
-    throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) + " but received " +
-                                std::to_string(v.size()));
+    throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
+                                " but received " + std::to_string(v.size()));
   }
-  const std::size_t nv_root = model.joints[(model.existJointName("root_joint") ? model.getJointId("root_joint") : 0)].nv();
+  const std::size_t nv_root = model
+                                  .joints[(model.existJointName("root_joint")
+                                               ? model.getJointId("root_joint")
+                                               : 0)]
+                                  .nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints)) {
-    throw std::invalid_argument("Expected tau to be " + std::to_string(njoints) + " but received " +
+    throw std::invalid_argument("Expected tau to be " +
+                                std::to_string(njoints) + " but received " +
                                 std::to_string(tau.size()));
   }
   if (msg.joints.size() != static_cast<std::size_t>(njoints)) {
-    throw std::invalid_argument("Message incorrect - msg.joints size is " + std::to_string(msg.joints.size()) +
-                                " but expected to be " + std::to_string(njoints));
+    throw std::invalid_argument("Message incorrect - msg.joints size is " +
+                                std::to_string(msg.joints.size()) +
+                                " but expected to be " +
+                                std::to_string(njoints));
   }
   t = msg.time;
   // Retrieve the joint state
@@ -508,59 +548,69 @@ static inline void fromMsg(const pinocchio::ModelTpl<double, Options, JointColle
                                      q(5))
                       .toRotationMatrix()
                       .transpose() *
-                  v.head<3>();  // local frame
+                  v.head<3>(); // local frame
   } else if (nv_root != 0) {
-    std::cerr << "Warning: fromMsg conversion does not yet support root joints "
-                 "different to a floating base. We cannot publish base information."
-              << std::endl;
+    std::cerr
+        << "Warning: fromMsg conversion does not yet support root joints "
+           "different to a floating base. We cannot publish base information."
+        << std::endl;
   }
 
   // Retrieve the contact information
   for (const auto &contact : msg.contacts) {
     // Contact pose
-    p[contact.name] =
-        pinocchio::SE3(Eigen::Quaterniond(contact.pose.orientation.w, contact.pose.orientation.x,
-                                          contact.pose.orientation.y, contact.pose.orientation.z),
-                       Eigen::Vector3d(contact.pose.position.x, contact.pose.position.y, contact.pose.position.z));
+    p[contact.name] = pinocchio::SE3(
+        Eigen::Quaterniond(
+            contact.pose.orientation.w, contact.pose.orientation.x,
+            contact.pose.orientation.y, contact.pose.orientation.z),
+        Eigen::Vector3d(contact.pose.position.x, contact.pose.position.y,
+                        contact.pose.position.z));
     // Contact velocity
     pd[contact.name] = pinocchio::Motion(
-        Eigen::Vector3d(contact.velocity.linear.x, contact.velocity.linear.y, contact.velocity.linear.z),
-        Eigen::Vector3d(contact.velocity.angular.x, contact.velocity.angular.y, contact.velocity.angular.z));
+        Eigen::Vector3d(contact.velocity.linear.x, contact.velocity.linear.y,
+                        contact.velocity.linear.z),
+        Eigen::Vector3d(contact.velocity.angular.x, contact.velocity.angular.y,
+                        contact.velocity.angular.z));
     // Contact wrench
     ContactType type;
     switch (contact.type) {
-      case ContactState::LOCOMOTION:
-        type = ContactType::LOCOMOTION;
-        break;
-      case ContactState::MANIPULATION:
-        type = ContactType::MANIPULATION;
-        break;
+    case ContactState::LOCOMOTION:
+      type = ContactType::LOCOMOTION;
+      break;
+    case ContactState::MANIPULATION:
+      type = ContactType::MANIPULATION;
+      break;
     }
     ContactStatus status;
     switch (contact.status) {
-      case ContactState::UNKNOWN:
-        status = ContactStatus::UNKNOWN;
-        break;
-      case ContactState::INACTIVE:
-        status = ContactStatus::SEPARATION;
-        break;
-      case ContactState::ACTIVE:
-        status = ContactStatus::STICKING;
-        break;
-      case ContactState::SLIPPING:
-        status = ContactStatus::SLIPPING;
-        break;
+    case ContactState::UNKNOWN:
+      status = ContactStatus::UNKNOWN;
+      break;
+    case ContactState::INACTIVE:
+      status = ContactStatus::SEPARATION;
+      break;
+    case ContactState::ACTIVE:
+      status = ContactStatus::STICKING;
+      break;
+    case ContactState::SLIPPING:
+      status = ContactStatus::SLIPPING;
+      break;
     }
     f[contact.name] = {
-        pinocchio::Force(Eigen::Vector3d(contact.wrench.force.x, contact.wrench.force.y, contact.wrench.force.z),
-                         Eigen::Vector3d(contact.wrench.torque.x, contact.wrench.torque.y, contact.wrench.torque.z)),
+        pinocchio::Force(
+            Eigen::Vector3d(contact.wrench.force.x, contact.wrench.force.y,
+                            contact.wrench.force.z),
+            Eigen::Vector3d(contact.wrench.torque.x, contact.wrench.torque.y,
+                            contact.wrench.torque.z)),
         type, status};
     // Surface normal and friction coefficient
-    s[contact.name] = {Eigen::Vector3d(contact.surface_normal.x, contact.surface_normal.y, contact.surface_normal.z),
+    s[contact.name] = {Eigen::Vector3d(contact.surface_normal.x,
+                                       contact.surface_normal.y,
+                                       contact.surface_normal.z),
                        contact.friction_coefficient};
   }
 }
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CONVERSIONS_H_
+#endif // CONVERSIONS_H_

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -521,7 +521,7 @@ fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
     q(q_idx) = msg.joints[j].position;
     v(v_idx) = msg.joints[j].velocity;
     a(v_idx) = msg.joints[j].acceleration;
-    tau(joint_id - 2) = msg.joints[j].effort;
+    tau(v_idx - nv_root) = msg.joints[j].effort;
   }
 
   // Retrieve the base state

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -185,7 +185,7 @@ static inline void toMsg(const pinocchio::ModelTpl<double, Options, JointCollect
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) + " but received " +
                                 std::to_string(a.size()));
   }
-  const std::size_t nv_root = model.joints[1].idx_q() == 0 ? model.joints[1].nv() : 0;
+  const std::size_t nv_root = model.joints[(model.existJointName("root_joint") ? model.getJointId("root_joint") : 0)].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints) && tau.size() != 0) {
     throw std::invalid_argument("Expected tau to be 0 or " + std::to_string(njoints) + " but received " +
@@ -462,7 +462,7 @@ static inline void fromMsg(const pinocchio::ModelTpl<double, Options, JointColle
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) + " but received " +
                                 std::to_string(v.size()));
   }
-  const std::size_t nv_root = model.joints[1].idx_q() == 0 ? model.joints[1].nv() : 0;
+  const std::size_t nv_root = model.joints[(model.existJointName("root_joint") ? model.getJointId("root_joint") : 0)].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints)) {
     throw std::invalid_argument("Expected tau to be " + std::to_string(njoints) + " but received " +

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -15,6 +15,7 @@
 #include <pinocchio/algorithm/centroidal.hpp>
 #include <pinocchio/algorithm/frames.hpp>
 #include <pinocchio/algorithm/joint-configuration.hpp>
+#include <pinocchio/algorithm/model.hpp>
 #include <pinocchio/container/aligned-vector.hpp>
 #include <pinocchio/multibody/data.hpp>
 #include <pinocchio/multibody/model.hpp>
@@ -618,6 +619,200 @@ fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
                                        contact.surface_normal.z),
                        contact.friction_coefficient};
   }
+}
+
+/**
+ * @brief Conversion from reduced position, velocity and effort to a full one
+ *
+ * @param model[in]  Pinocchio model
+ * @param reduced_model[in]  Reduced Pinocchio model
+ * @param q_out[out]  Configuration vector (dimension: model.nq)
+ * @param v_out[out]  Generalized velocity (dimension: model.nv)
+ * @param tau_out[out]  Joint effort (dimension: model.nv - nv_root)
+ * @param q[in]  Reduced configuration vector (dimension: reduced_model.nq)
+ * @param v[in]  Reduced generalized velocity (dimension: reduced_model.nv)
+ * @param tau[in]  Reduced joint effort (dimension: reduced_model.nv - nv_root)
+ * @param qref[in]  Reference configuration used in the reduced model
+ * @param locked_joint_ids[in]  Ids of the locked joints
+ */
+template <int Options, template <typename, int> class JointCollectionTpl>
+static inline void fromReduced(
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl>
+        &reduced_model,
+    Eigen::Ref<Eigen::VectorXd> q_out, Eigen::Ref<Eigen::VectorXd> v_out,
+    Eigen::Ref<Eigen::VectorXd> tau_out,
+    const Eigen::Ref<const Eigen::VectorXd> &q_in,
+    const Eigen::Ref<const Eigen::VectorXd> &v_in,
+    const Eigen::Ref<const Eigen::VectorXd> &tau_in,
+    const Eigen::Ref<const Eigen::VectorXd> &qref,
+    const std::vector<pinocchio::JointIndex> &locked_joint_ids) {
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t nq_root = model.joints[root_joint_id].nq();
+  const std::size_t nv_root = model.joints[root_joint_id].nv();
+  if (q_out.size() != model.nq) {
+    throw std::invalid_argument("Expected q_out to be " +
+                                std::to_string(model.nq) + " but received " +
+                                std::to_string(q_out.size()));
+  }
+  if (q_in.size() != reduced_model.nq) {
+    throw std::invalid_argument("Expected q_in to be " +
+                                std::to_string(reduced_model.nq) +
+                                " but received " + std::to_string(q_in.size()));
+  }
+  if (v_out.size() != model.nv) {
+    throw std::invalid_argument("Expected v_out to be " +
+                                std::to_string(model.nv) + " but received " +
+                                std::to_string(v_out.size()));
+  }
+  if (v_in.size() != reduced_model.nv) {
+    throw std::invalid_argument("Expected v_in to be " +
+                                std::to_string(reduced_model.nv) +
+                                " but received " + std::to_string(v_in.size()));
+  }
+  if (static_cast<std::size_t>(tau_out.size()) != model.nv - nv_root) {
+    throw std::invalid_argument(
+        "Expected tau_out to be " + std::to_string(model.nv - nv_root) +
+        " but received " + std::to_string(tau_out.size()));
+  }
+  if (static_cast<std::size_t>(tau_in.size()) != reduced_model.nv - nv_root) {
+    throw std::invalid_argument(
+        "Expected tau_in to be " + std::to_string(reduced_model.nv - nv_root) +
+        " but received " + std::to_string(tau_in.size()));
+  }
+
+  typedef pinocchio::ModelTpl<double, Options, JointCollectionTpl> Model;
+  typedef typename Model::JointModel JointModel;
+
+  q_out.head(nq_root) = q_in.head(nq_root);
+  v_out.head(nv_root) = v_in.head(nv_root);
+  for (std::size_t j = root_joint_id;
+       j < static_cast<std::size_t>(model.njoints); ++j) {
+    const std::string &name = model.names[j];
+    JointModel joint = model.joints[model.getJointId(name)];
+    JointModel reduced_joint = model.joints[reduced_model.getJointId(name)];
+    q_out(joint.idx_q()) = q_in(reduced_joint.idx_q());
+    v_out(joint.idx_v()) = v_in(reduced_joint.idx_v());
+    tau_out(joint.idx_v() - nv_root) = tau_in(reduced_joint.idx_v() - nv_root);
+  }
+  for (pinocchio::JointIndex joint_id : locked_joint_ids) {
+    JointModel joint = model.joints[joint_id];
+    q_out(joint.idx_q()) = qref(joint.idx_q());
+    v_out(joint.idx_v()) = 0.;
+    tau_out(joint.idx_v() - nv_root) = 0.;
+  }
+}
+
+/**
+ * @brief Conversion to reduced position, velocity and effort from a full one
+ *
+ * @param model[in]  Pinocchio model
+ * @param reduced_model[in]  Reduced Pinocchio model
+ * @param q_out[out]  Reduced configuration vector (dimension: reduced_model.nq)
+ * @param v_out[out]  Reduced generalized velocity (dimension: reduced_model.nv)
+ * @param tau_out[out]  Reduced joint effort (dimension: reduced_model.nv -
+ * nv_root)
+ * @param q[in]  Configuration vector (dimension: model.nq)
+ * @param v[in]  Generalized velocity (dimension: model.nv)
+ * @param tau[in]  Joint effort (dimension: model.nv - nv_root)
+ */
+template <int Options, template <typename, int> class JointCollectionTpl>
+static inline void
+toReduced(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+          const pinocchio::ModelTpl<double, Options, JointCollectionTpl>
+              &reduced_model,
+          Eigen::Ref<Eigen::VectorXd> q_out, Eigen::Ref<Eigen::VectorXd> v_out,
+          Eigen::Ref<Eigen::VectorXd> tau_out,
+          const Eigen::Ref<const Eigen::VectorXd> &q_in,
+          const Eigen::Ref<const Eigen::VectorXd> &v_in,
+          const Eigen::Ref<const Eigen::VectorXd> &tau_in) {
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t nq_root = model.joints[root_joint_id].nq();
+  const std::size_t nv_root = model.joints[root_joint_id].nv();
+  if (q_out.size() != reduced_model.nq) {
+    throw std::invalid_argument(
+        "Expected q_out to be " + std::to_string(reduced_model.nq) +
+        " but received " + std::to_string(q_out.size()));
+  }
+  if (q_in.size() != model.nq) {
+    throw std::invalid_argument("Expected q_in to be " +
+                                std::to_string(model.nq) + " but received " +
+                                std::to_string(q_in.size()));
+  }
+  if (v_out.size() != reduced_model.nv) {
+    throw std::invalid_argument(
+        "Expected v_out to be " + std::to_string(reduced_model.nv) +
+        " but received " + std::to_string(v_out.size()));
+  }
+  if (v_in.size() != model.nv) {
+    throw std::invalid_argument("Expected v_in to be " +
+                                std::to_string(model.nv) + " but received " +
+                                std::to_string(v_in.size()));
+  }
+  if (static_cast<std::size_t>(tau_out.size()) != reduced_model.nv - nv_root) {
+    throw std::invalid_argument(
+        "Expected tau_out to be " + std::to_string(reduced_model.nv - nv_root) +
+        " but received " + std::to_string(tau_out.size()));
+  }
+  if (static_cast<std::size_t>(tau_in.size()) != model.nv - nv_root) {
+    throw std::invalid_argument(
+        "Expected tau_in to be " + std::to_string(model.nv - nv_root) +
+        " but received " + std::to_string(tau_in.size()));
+  }
+
+  typedef pinocchio::ModelTpl<double, Options, JointCollectionTpl> Model;
+  typedef typename Model::JointModel JointModel;
+
+  q_out.head(nq_root) = q_in.head(nq_root);
+  v_out.head(nv_root) = v_in.head(nv_root);
+  for (std::size_t j = root_joint_id;
+       j < static_cast<std::size_t>(model.njoints); ++j) {
+    const std::string &name = model.names[j];
+    JointModel joint = model.joints[model.getJointId(name)];
+    JointModel reduced_joint = model.joints[reduced_model.getJointId(name)];
+    q_out(reduced_joint.idx_q()) = q_in(joint.idx_q());
+    v_out(reduced_joint.idx_v()) = v_in(joint.idx_v());
+    tau_out(reduced_joint.idx_v() - nv_root) = tau_in(joint.idx_v() - nv_root);
+  }
+}
+
+template <int Options, template <typename, int> class JointCollectionTpl>
+static inline std::tuple<Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>
+fromReduced_return(
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl>
+        &reduced_model,
+    const Eigen::Ref<const Eigen::VectorXd> &q_in,
+    const Eigen::Ref<const Eigen::VectorXd> &v_in,
+    const Eigen::Ref<const Eigen::VectorXd> &tau_in,
+    const Eigen::Ref<const Eigen::VectorXd> &qref,
+    const std::vector<pinocchio::JointIndex> &locked_joint_ids) {
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  Eigen::VectorXd q_out = Eigen::VectorXd::Zero(model.nq);
+  Eigen::VectorXd v_out = Eigen::VectorXd::Zero(model.nv);
+  Eigen::VectorXd tau_out =
+      Eigen::VectorXd::Zero(model.nv - model.joints[root_joint_id].nv());
+  fromReduced(model, reduced_model, q_out, v_out, tau_out, q_in, v_in, tau_in,
+              qref, locked_joint_ids);
+  return {q_out, v_out, tau_out};
+}
+
+template <int Options, template <typename, int> class JointCollectionTpl>
+static inline std::tuple<Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>
+toReduced_return(
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl>
+        &reduced_model,
+    const Eigen::Ref<const Eigen::VectorXd> &q_in,
+    const Eigen::Ref<const Eigen::VectorXd> &v_in,
+    const Eigen::Ref<const Eigen::VectorXd> &tau_in) {
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  Eigen::VectorXd q_out = Eigen::VectorXd::Zero(reduced_model.nq);
+  Eigen::VectorXd v_out = Eigen::VectorXd::Zero(reduced_model.nv);
+  Eigen::VectorXd tau_out = Eigen::VectorXd::Zero(
+      reduced_model.nv - model.joints[root_joint_id].nv());
+  toReduced(model, reduced_model, q_out, v_out, tau_out, q_in, v_in, tau_in);
+  return {q_out, v_out, tau_out};
 }
 
 } // namespace crocoddyl_msgs

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -688,9 +688,9 @@ static inline void fromReduced(
 
   q_out.head(nq_root) = q_in.head(nq_root);
   v_out.head(nv_root) = v_in.head(nv_root);
-  for (std::size_t j = root_joint_id;
-       j < static_cast<std::size_t>(model.njoints); ++j) {
-    const std::string &name = model.names[j];
+  for (std::size_t j = root_joint_id + 1;
+       j < static_cast<std::size_t>(reduced_model.njoints); ++j) {
+    const std::string &name = reduced_model.names[j];
     JointModel joint = model.joints[model.getJointId(name)];
     JointModel reduced_joint = model.joints[reduced_model.getJointId(name)];
     q_out(joint.idx_q()) = q_in(reduced_joint.idx_q());
@@ -767,9 +767,9 @@ toReduced(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
 
   q_out.head(nq_root) = q_in.head(nq_root);
   v_out.head(nv_root) = v_in.head(nv_root);
-  for (std::size_t j = root_joint_id;
-       j < static_cast<std::size_t>(model.njoints); ++j) {
-    const std::string &name = model.names[j];
+  for (std::size_t j = root_joint_id + 1;
+       j < static_cast<std::size_t>(reduced_model.njoints); ++j) {
+    const std::string &name = reduced_model.names[j];
     JointModel joint = model.joints[model.getJointId(name)];
     JointModel reduced_joint = model.joints[reduced_model.getJointId(name)];
     q_out(reduced_joint.idx_q()) = q_in(joint.idx_q());

--- a/include/crocoddyl_msgs/conversions.h
+++ b/include/crocoddyl_msgs/conversions.h
@@ -72,6 +72,21 @@ typedef whole_body_state_msgs::ContactState ContactState;
 #endif
 
 /**
+ * @brief Return the root joint id
+ *
+ * @param return  Root joint Id
+ */
+template <int Options, template <typename, int> class JointCollectionTpl>
+static inline std::size_t get_root_joint_id(
+    const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model) {
+  return model.existJointName("root_joint")
+             ? model.getJointId("root_joint")
+             : (model.existJointName("freeflyer_joint")
+                    ? model.getJointId("freeflyer_joint")
+                    : 0);
+}
+
+/**
  * @brief Conversion of Eigen to message for a given
  * crocoddyl_msgs::FeedbackGain message reference
  *
@@ -193,11 +208,8 @@ static inline void toMsg(
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(a.size()));
   }
-  const std::size_t nv_root = model
-                                  .joints[(model.existJointName("root_joint")
-                                               ? model.getJointId("root_joint")
-                                               : 0)]
-                                  .nv();
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t nv_root = model.joints[root_joint_id].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints) && tau.size() != 0) {
     throw std::invalid_argument("Expected tau to be 0 or " +
@@ -495,11 +507,8 @@ fromMsg(const pinocchio::ModelTpl<double, Options, JointCollectionTpl> &model,
     throw std::invalid_argument("Expected a to be " + std::to_string(model.nv) +
                                 " but received " + std::to_string(v.size()));
   }
-  const std::size_t nv_root = model
-                                  .joints[(model.existJointName("root_joint")
-                                               ? model.getJointId("root_joint")
-                                               : 0)]
-                                  .nv();
+  const std::size_t root_joint_id = get_root_joint_id(model);
+  const std::size_t nv_root = model.joints[root_joint_id].nv();
   const std::size_t njoints = model.nv - nv_root;
   if (tau.size() != static_cast<int>(njoints)) {
     throw std::invalid_argument("Expected tau to be " +

--- a/include/crocoddyl_msgs/solver_statistics_publisher.h
+++ b/include/crocoddyl_msgs/solver_statistics_publisher.h
@@ -27,17 +27,16 @@ public:
    *
    * @param[in] topic  Topic name
    */
-#ifdef ROS2
   SolverStatisticsRosPublisher(
       const std::string &topic = "/crocoddyl/solver_statistics")
+#ifdef ROS2
       : node_("solver_statistics_publisher"),
         pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverStatistics>(
             topic, 1)) {
     RCLCPP_INFO_STREAM(node_.get_logger(),
                        "Publishing SolverStatistics messages on " << topic);
 #else
-  SolverStatisticsRosPublisher(
-      const std::string &topic = "/crocoddyl/solver_statistics") {
+  {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
     ROS_INFO_STREAM("Publishing SolverStatistics messages on " << topic);

--- a/include/crocoddyl_msgs/solver_statistics_publisher.h
+++ b/include/crocoddyl_msgs/solver_statistics_publisher.h
@@ -12,8 +12,8 @@
 #include <realtime_tools/realtime_publisher.h>
 
 #ifdef ROS2
-#include <rclcpp/rclcpp.hpp>
 #include "crocoddyl_msgs/msg/solver_statistics.hpp"
+#include <rclcpp/rclcpp.hpp>
 #else
 #include "crocoddyl_msgs/SolverStatistics.h"
 #endif
@@ -21,19 +21,23 @@
 namespace crocoddyl_msgs {
 
 class SolverStatisticsRosPublisher {
- public:
+public:
   /**
    * @brief Initialize the solver statistic publisher
    *
    * @param[in] topic  Topic name
    */
 #ifdef ROS2
-  SolverStatisticsRosPublisher(const std::string &topic = "/crocoddyl/solver_statistics")
+  SolverStatisticsRosPublisher(
+      const std::string &topic = "/crocoddyl/solver_statistics")
       : node_("solver_statistics_publisher"),
-        pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverStatistics>(topic, 1)) {
-    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing SolverStatistics messages on " << topic);
+        pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverStatistics>(
+            topic, 1)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(),
+                       "Publishing SolverStatistics messages on " << topic);
 #else
-  SolverStatisticsRosPublisher(const std::string &topic = "/crocoddyl/solver_statistics") {
+  SolverStatisticsRosPublisher(
+      const std::string &topic = "/crocoddyl/solver_statistics") {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
     ROS_INFO_STREAM("Publishing SolverStatistics messages on " << topic);
@@ -54,8 +58,10 @@ class SolverStatisticsRosPublisher {
    * @param equafeas[in]        Equality constraints feasibility
    * @param ineqfeas[in]        Inequality constraints feasibility
    */
-  void publish(const std::size_t iterations, const double totaltime, const double solvetime, const double cost,
-               const double regularization, const double steplength, const double dynfeas, const double equafeas,
+  void publish(const std::size_t iterations, const double totaltime,
+               const double solvetime, const double cost,
+               const double regularization, const double steplength,
+               const double dynfeas, const double equafeas,
                const double ineqfeas) {
     if (pub_.trylock()) {
 #ifdef ROS2
@@ -76,7 +82,7 @@ class SolverStatisticsRosPublisher {
     }
   }
 
- private:
+private:
 #ifdef ROS2
   rclcpp::Node node_;
   realtime_tools::RealtimePublisher<crocoddyl_msgs::msg::SolverStatistics> pub_;
@@ -85,6 +91,6 @@ class SolverStatisticsRosPublisher {
 #endif
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_SOLVER_STATISTICS_PUBLISHER_H_
+#endif // CROCODDYL_MSG_SOLVER_STATISTICS_PUBLISHER_H_

--- a/include/crocoddyl_msgs/solver_statistics_subscriber.h
+++ b/include/crocoddyl_msgs/solver_statistics_subscriber.h
@@ -11,11 +11,11 @@
 
 #include <mutex>
 #ifdef ROS2
-#include <rclcpp/rclcpp.hpp>
 #include "crocoddyl_msgs/msg/solver_statistics.hpp"
+#include <rclcpp/rclcpp.hpp>
 #else
-#include <ros/node_handle.h>
 #include "crocoddyl_msgs/SolverStatistics.h"
+#include <ros/node_handle.h>
 #endif
 
 namespace crocoddyl_msgs {
@@ -29,30 +29,35 @@ typedef const SolverStatistics::ConstPtr &SolverStatisticsSharedPtr;
 #endif
 
 class SolverStatisticsRosSubscriber {
- public:
+public:
   /**
    * @brief Initialize the solver statistic subscriber
    *
    * @param[in] topic  Topic name
    */
 #ifdef ROS2
-  SolverStatisticsRosSubscriber(const std::string &topic = "/crocoddyl/solver_statistics")
+  SolverStatisticsRosSubscriber(
+      const std::string &topic = "/crocoddyl/solver_statistics")
       : node_(rclcpp::Node::make_shared("solver_statistics_subscriber")),
         sub_(node_->create_subscription<SolverStatistics>(
-            topic, 1, std::bind(&SolverStatisticsRosSubscriber::callback, this, std::placeholders::_1))),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.) {
+            topic, 1,
+            std::bind(&SolverStatisticsRosSubscriber::callback, this,
+                      std::placeholders::_1))),
+        has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
-    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing SolverStatistics messages on " << topic);
+    RCLCPP_INFO_STREAM(node_->get_logger(),
+                       "Subscribing SolverStatistics messages on " << topic);
 #else
-  SolverStatisticsRosSubscriber(const std::string &topic = "/crocoddyl/solver_statistics")
-      : spinner_(2), has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
+  SolverStatisticsRosSubscriber(
+      const std::string &topic = "/crocoddyl/solver_statistics")
+      : spinner_(2), has_new_msg_(false), is_processing_msg_(false),
+        last_msg_time_(0.) {
     ros::NodeHandle n;
-    sub_ = n.subscribe<SolverStatistics>(topic, 1, &SolverStatisticsRosSubscriber::callback, this,
-                                         ros::TransportHints().tcpNoDelay());
+    sub_ = n.subscribe<SolverStatistics>(
+        topic, 1, &SolverStatisticsRosSubscriber::callback, this,
+        ros::TransportHints().tcpNoDelay());
     spinner_.start();
     ROS_INFO_STREAM("Subscribing SolverStatistics messages on " << topic);
 #endif
@@ -66,7 +71,9 @@ class SolverStatisticsRosSubscriber {
    * cost, regularization, step legth, dynamic, equality and inequality
    * feasibilities.
    */
-  std::tuple<std::size_t, double, double, double, double, double, double, double, double> get_solver_statistics() {
+  std::tuple<std::size_t, double, double, double, double, double, double,
+             double, double>
+  get_solver_statistics() {
     // start processing the message
     is_processing_msg_ = true;
     std::lock_guard<std::mutex> guard(mutex_);
@@ -98,23 +105,23 @@ class SolverStatisticsRosSubscriber {
    */
   bool has_new_msg() const { return has_new_msg_; }
 
- private:
+private:
 #ifdef ROS2
   std::shared_ptr<rclcpp::Node> node_;
   rclcpp::executors::SingleThreadedExecutor spinner_;
   std::thread thread_;
   void spin() { spinner_.spin(); }
-  rclcpp::Subscription<SolverStatistics>::SharedPtr sub_;  //!< ROS subscriber
+  rclcpp::Subscription<SolverStatistics>::SharedPtr sub_; //!< ROS subscriber
 #else
   ros::AsyncSpinner spinner_;
-  ros::Subscriber sub_;  //!< ROS subscriber
+  ros::Subscriber sub_; //!< ROS subscriber
 #endif
-  SolverStatistics msg_;    //!< Solver statistics message
-  std::mutex mutex_;        //!< Mutex to prevent race condition on callback
-  bool has_new_msg_;        //!< Indcate when a new message has been received
-  bool is_processing_msg_;  //!< Indicate when we are processing the message
-  double last_msg_time_;    //!< Last message time needed to ensure each message is
-                            //!< newer
+  SolverStatistics msg_;   //!< Solver statistics message
+  std::mutex mutex_;       //!< Mutex to prevent race condition on callback
+  bool has_new_msg_;       //!< Indcate when a new message has been received
+  bool is_processing_msg_; //!< Indicate when we are processing the message
+  double last_msg_time_; //!< Last message time needed to ensure each message is
+                         //!< newer
   std::size_t iterations_;
   double total_time_;
   double solve_time_;
@@ -140,17 +147,20 @@ class SolverStatisticsRosSubscriber {
         last_msg_time_ = t;
       } else {
 #ifdef ROS2
-        RCLCPP_WARN_STREAM(node_->get_logger(), "Out of order message. Last timestamp: "
-                                                    << std::fixed << last_msg_time_ << ", current timestamp: " << t);
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+                           "Out of order message. Last timestamp: "
+                               << std::fixed << last_msg_time_
+                               << ", current timestamp: " << t);
 #else
-        ROS_WARN_STREAM("Out of order message. Last timestamp: " << std::fixed << last_msg_time_
-                                                                 << ", current timestamp: " << t);
+        ROS_WARN_STREAM("Out of order message. Last timestamp: "
+                        << std::fixed << last_msg_time_
+                        << ", current timestamp: " << t);
 #endif
       }
     }
   }
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_SOLVER_STATISTICS_SUBSCRIBER_H_
+#endif // CROCODDYL_MSG_SOLVER_STATISTICS_SUBSCRIBER_H_

--- a/include/crocoddyl_msgs/solver_statistics_subscriber.h
+++ b/include/crocoddyl_msgs/solver_statistics_subscriber.h
@@ -35,9 +35,9 @@ public:
    *
    * @param[in] topic  Topic name
    */
-#ifdef ROS2
   SolverStatisticsRosSubscriber(
       const std::string &topic = "/crocoddyl/solver_statistics")
+#ifdef ROS2
       : node_(rclcpp::Node::make_shared("solver_statistics_subscriber")),
         sub_(node_->create_subscription<SolverStatistics>(
             topic, 1,
@@ -50,14 +50,11 @@ public:
     RCLCPP_INFO_STREAM(node_->get_logger(),
                        "Subscribing SolverStatistics messages on " << topic);
 #else
-  SolverStatisticsRosSubscriber(
-      const std::string &topic = "/crocoddyl/solver_statistics")
-      : spinner_(2), has_new_msg_(false), is_processing_msg_(false),
-        last_msg_time_(0.) {
-    ros::NodeHandle n;
-    sub_ = n.subscribe<SolverStatistics>(
-        topic, 1, &SolverStatisticsRosSubscriber::callback, this,
-        ros::TransportHints().tcpNoDelay());
+      : node_(), spinner_(2),
+        sub_(node_.subscribe<SolverStatistics>(
+            topic, 1, &SolverStatisticsRosSubscriber::callback, this,
+            ros::TransportHints().tcpNoDelay())),
+        has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
     spinner_.start();
     ROS_INFO_STREAM("Subscribing SolverStatistics messages on " << topic);
 #endif
@@ -113,6 +110,7 @@ private:
   void spin() { spinner_.spin(); }
   rclcpp::Subscription<SolverStatistics>::SharedPtr sub_; //!< ROS subscriber
 #else
+  ros::NodeHandle node_;
   ros::AsyncSpinner spinner_;
   ros::Subscriber sub_; //!< ROS subscriber
 #endif
@@ -131,6 +129,7 @@ private:
   double dynamic_feasibility_;
   double equality_feasibility_;
   double inequality_feasibility_;
+
   void callback(SolverStatisticsSharedPtr msg) {
     if (!is_processing_msg_) {
 #ifdef ROS2

--- a/include/crocoddyl_msgs/solver_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/solver_trajectory_publisher.h
@@ -15,17 +15,17 @@
 #include <realtime_tools/realtime_publisher.h>
 
 #ifdef ROS2
-#include <rclcpp/rclcpp.hpp>
 #include "crocoddyl_msgs/msg/solver_trajectory.hpp"
+#include <rclcpp/rclcpp.hpp>
 #else
-#include <ros/node_handle.h>
 #include "crocoddyl_msgs/SolverTrajectory.h"
+#include <ros/node_handle.h>
 #endif
 
 namespace crocoddyl_msgs {
 
 class SolverTrajectoryRosPublisher {
- public:
+public:
   /**
    * @brief Initialize the solver trajectory publisher
    *
@@ -33,17 +33,23 @@ class SolverTrajectoryRosPublisher {
    * @param[in] frame  Odometry frame
    */
 #ifdef ROS2
-  SolverTrajectoryRosPublisher(const std::string &topic = "/crocoddyl/solver_trajectory",
-                               const std::string &frame = "odom")
+  SolverTrajectoryRosPublisher(
+      const std::string &topic = "/crocoddyl/solver_trajectory",
+      const std::string &frame = "odom")
       : node_("solver_trajectory_publisher"),
-        pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverTrajectory>(topic, 1)) {
-    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing SolverTrajectory messages on " << topic <<  " (frame: " << frame << ")");
+        pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverTrajectory>(
+            topic, 1)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(),
+                       "Publishing SolverTrajectory messages on "
+                           << topic << " (frame: " << frame << ")");
 #else
-  SolverTrajectoryRosPublisher(const std::string &topic = "/crocoddyl/solver_trajectory",
-                               const std::string &frame = "odom") {
+  SolverTrajectoryRosPublisher(
+      const std::string &topic = "/crocoddyl/solver_trajectory",
+      const std::string &frame = "odom") {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
-    ROS_INFO_STREAM("Publishing SolverTrajectory messages on " << topic <<  " (frame: " << frame << ")");
+    ROS_INFO_STREAM("Publishing SolverTrajectory messages on "
+                    << topic << " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
   }
@@ -63,45 +69,41 @@ class SolverTrajectoryRosPublisher {
    * @param types[in]   Vector of control types of each interval
    * @param params[in]  Vector of control parametrizations of each interval
    */
-  void publish(const std::vector<double> &ts, const std::vector<double> &dts, const std::vector<Eigen::VectorXd> &xs,
-               const std::vector<Eigen::VectorXd> &dxs, const std::vector<Eigen::VectorXd> &us = {},
-               const std::vector<Eigen::MatrixXd> &Ks = {}, const std::vector<ControlType> &types = {},
+  void publish(const std::vector<double> &ts, const std::vector<double> &dts,
+               const std::vector<Eigen::VectorXd> &xs,
+               const std::vector<Eigen::VectorXd> &dxs,
+               const std::vector<Eigen::VectorXd> &us = {},
+               const std::vector<Eigen::MatrixXd> &Ks = {},
+               const std::vector<ControlType> &types = {},
                const std::vector<ControlParametrization> &params = {}) {
     if (pub_.trylock()) {
       if (ts.size() != dts.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the dts vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the dts vector.");
       }
       if (ts.size() != xs.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the xs vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the xs vector.");
       }
       if (ts.size() != dxs.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the dxs vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the dxs vector.");
       }
       if (us.size() != 0 && ts.size() != us.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the us vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the us vector.");
       }
       if (Ks.size() != 0 && ts.size() != Ks.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the Ks vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the Ks vector.");
       }
       if (types.size() != 0 && ts.size() != types.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the types.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the types.");
       }
       if (params.size() != 0 && ts.size() != params.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the params.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the params.");
       }
       const std::size_t N = ts.size();
 #ifdef ROS2
@@ -116,13 +118,14 @@ class SolverTrajectoryRosPublisher {
         pub_.msg_.intervals[i].time = ts[i];
         pub_.msg_.intervals[i].duration = dts[i];
         crocoddyl_msgs::toMsg(pub_.msg_.state_trajectory[i], xs[i], dxs[i]);
-        crocoddyl_msgs::toMsg(pub_.msg_.control_trajectory[i], us[i], Ks[i], types[i], params[i]);
+        crocoddyl_msgs::toMsg(pub_.msg_.control_trajectory[i], us[i], Ks[i],
+                              types[i], params[i]);
       }
       pub_.unlockAndPublish();
     }
   }
 
- private:
+private:
 #ifdef ROS2
   rclcpp::Node node_;
   realtime_tools::RealtimePublisher<crocoddyl_msgs::msg::SolverTrajectory> pub_;
@@ -131,6 +134,6 @@ class SolverTrajectoryRosPublisher {
 #endif
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_SOLVER_TRAJECTORY_PUBLISHER_H_
+#endif // CROCODDYL_MSG_SOLVER_TRAJECTORY_PUBLISHER_H_

--- a/include/crocoddyl_msgs/solver_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/solver_trajectory_publisher.h
@@ -32,10 +32,10 @@ public:
    * @param[in] topic  Topic name
    * @param[in] frame  Odometry frame
    */
-#ifdef ROS2
   SolverTrajectoryRosPublisher(
       const std::string &topic = "/crocoddyl/solver_trajectory",
       const std::string &frame = "odom")
+#ifdef ROS2
       : node_("solver_trajectory_publisher"),
         pub_(node_.create_publisher<crocoddyl_msgs::msg::SolverTrajectory>(
             topic, 1)) {
@@ -43,9 +43,7 @@ public:
                        "Publishing SolverTrajectory messages on "
                            << topic << " (frame: " << frame << ")");
 #else
-  SolverTrajectoryRosPublisher(
-      const std::string &topic = "/crocoddyl/solver_trajectory",
-      const std::string &frame = "odom") {
+  {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
     ROS_INFO_STREAM("Publishing SolverTrajectory messages on "

--- a/include/crocoddyl_msgs/solver_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/solver_trajectory_subscriber.h
@@ -14,11 +14,11 @@
 #include <Eigen/Dense>
 #include <mutex>
 #ifdef ROS2
-#include <rclcpp/rclcpp.hpp>
 #include "crocoddyl_msgs/msg/solver_trajectory.hpp"
+#include <rclcpp/rclcpp.hpp>
 #else
-#include <ros/node_handle.h>
 #include "crocoddyl_msgs/SolverTrajectory.h"
+#include <ros/node_handle.h>
 #endif
 
 namespace crocoddyl_msgs {
@@ -32,7 +32,7 @@ typedef const SolverTrajectory::ConstPtr &SolverTrajectorySharedPtr;
 #endif
 
 class SolverTrajectoryRosSubscriber {
- public:
+public:
   /**
    * @brief Initialize the solver trajectory subscriber
    *
@@ -40,23 +40,28 @@ class SolverTrajectoryRosSubscriber {
    * @param[in] frame  Odometry frame
    */
 #ifdef ROS2
-  SolverTrajectoryRosSubscriber(const std::string &topic = "/crocoddyl/solver_trajectory")
+  SolverTrajectoryRosSubscriber(
+      const std::string &topic = "/crocoddyl/solver_trajectory")
       : node_(rclcpp::Node::make_shared("solver_trajectory_subscriber")),
         sub_(node_->create_subscription<SolverTrajectory>(
-            topic, 1, std::bind(&SolverTrajectoryRosSubscriber::callback, this, std::placeholders::_1))),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.) {
+            topic, 1,
+            std::bind(&SolverTrajectoryRosSubscriber::callback, this,
+                      std::placeholders::_1))),
+        has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
-    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing SolverTrajectory messages on " << topic);
+    RCLCPP_INFO_STREAM(node_->get_logger(),
+                       "Subscribing SolverTrajectory messages on " << topic);
 #else
-  SolverTrajectoryRosSubscriber(const std::string &topic = "/crocoddyl/solver_trajectory")
-      : spinner_(2), has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.) {
+  SolverTrajectoryRosSubscriber(
+      const std::string &topic = "/crocoddyl/solver_trajectory")
+      : spinner_(2), has_new_msg_(false), is_processing_msg_(false),
+        last_msg_time_(0.) {
     ros::NodeHandle n;
-    sub_ = n.subscribe<SolverTrajectory>(topic, 1, &SolverTrajectoryRosSubscriber::callback, this,
-                                         ros::TransportHints().tcpNoDelay());
+    sub_ = n.subscribe<SolverTrajectory>(
+        topic, 1, &SolverTrajectoryRosSubscriber::callback, this,
+        ros::TransportHints().tcpNoDelay());
     spinner_.start();
     ROS_INFO_STREAM("Subscribing SolverTrajectory messages on " << topic);
 #endif
@@ -70,8 +75,10 @@ class SolverTrajectoryRosSubscriber {
    * its durations, initial state, state's rate of change, feed-forward control,
    * feedback gain, type of control and control parametrization.
    */
-  std::tuple<std::vector<double>, std::vector<double>, std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>,
-             std::vector<Eigen::VectorXd>, std::vector<Eigen::MatrixXd>, std::vector<crocoddyl_msgs::ControlType>,
+  std::tuple<std::vector<double>, std::vector<double>,
+             std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>,
+             std::vector<Eigen::VectorXd>, std::vector<Eigen::MatrixXd>,
+             std::vector<crocoddyl_msgs::ControlType>,
              std::vector<crocoddyl_msgs::ControlParametrization>>
   get_solver_trajectory() {
     // start processing the message
@@ -83,7 +90,8 @@ class SolverTrajectoryRosSubscriber {
           "The size of the state trajectory vector needs to equal "
           "the size of the intervals vector.");
     }
-    if (msg_.control_trajectory.size() != 0 && msg_.control_trajectory.size() != N) {
+    if (msg_.control_trajectory.size() != 0 &&
+        msg_.control_trajectory.size() != N) {
       throw std::invalid_argument(
           "The size of the control trajectory vector needs to equal "
           "the size of the intervals vector.");
@@ -120,23 +128,23 @@ class SolverTrajectoryRosSubscriber {
    */
   bool has_new_msg() const { return has_new_msg_; }
 
- private:
+private:
 #ifdef ROS2
   std::shared_ptr<rclcpp::Node> node_;
   rclcpp::executors::SingleThreadedExecutor spinner_;
   std::thread thread_;
   void spin() { spinner_.spin(); }
-  rclcpp::Subscription<SolverTrajectory>::SharedPtr sub_;  //!< ROS subscriber
+  rclcpp::Subscription<SolverTrajectory>::SharedPtr sub_; //!< ROS subscriber
 #else
   ros::AsyncSpinner spinner_;
-  ros::Subscriber sub_;  //!< ROS subscriber
+  ros::Subscriber sub_; //!< ROS subscriber
 #endif
-  std::mutex mutex_;        //!< Mutex to prevent race condition on callback
-  SolverTrajectory msg_;    //!< Solver trajectory message
-  bool has_new_msg_;        //!< Indcate when a new message has been received
-  bool is_processing_msg_;  //!< Indicate when we are processing the message
-  double last_msg_time_;    //!< Last message time needed to ensure each message is
-                            //!< newer
+  std::mutex mutex_;       //!< Mutex to prevent race condition on callback
+  SolverTrajectory msg_;   //!< Solver trajectory message
+  bool has_new_msg_;       //!< Indcate when a new message has been received
+  bool is_processing_msg_; //!< Indicate when we are processing the message
+  double last_msg_time_; //!< Last message time needed to ensure each message is
+                         //!< newer
   std::vector<double> ts_;
   std::vector<double> dts_;
   std::vector<Eigen::VectorXd> xs_;
@@ -161,17 +169,20 @@ class SolverTrajectoryRosSubscriber {
         last_msg_time_ = t;
       } else {
 #ifdef ROS2
-        RCLCPP_WARN_STREAM(node_->get_logger(), "Out of order message. Last timestamp: "
-                                                    << std::fixed << last_msg_time_ << ", current timestamp: " << t);
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+                           "Out of order message. Last timestamp: "
+                               << std::fixed << last_msg_time_
+                               << ", current timestamp: " << t);
 #else
-        ROS_WARN_STREAM("Out of order message. Last timestamp: " << std::fixed << last_msg_time_
-                                                                 << ", current timestamp: " << t);
+        ROS_WARN_STREAM("Out of order message. Last timestamp: "
+                        << std::fixed << last_msg_time_
+                        << ", current timestamp: " << t);
 #endif
       }
     }
   }
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_SOLVER_TRAJECTORY_SUBSCRIBER_H_
+#endif // CROCODDYL_MSG_SOLVER_TRAJECTORY_SUBSCRIBER_H_

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -24,7 +24,7 @@ namespace crocoddyl_msgs {
 class WholeBodyStateRosPublisher {
 public:
   /**
-   * @brief Initialize the whole-body state publisher
+   * @brief Initialize the whole-body state publisher.
    *
    * @param[in] model  Pinocchio model
    * @param[in] topic  Topic name
@@ -37,7 +37,8 @@ public:
       const std::string &frame = "odom")
       : node_("whole_body_state_publisher"),
         pub_(node_.create_publisher<WholeBodyState>(topic, 1)), model_(model),
-        data_(model), odom_frame_(frame), a_(Eigen::VectorXd::Zero(model.nv)) {
+        data_(model), odom_frame_(frame), a_(model.nv),
+        is_reduced_model_(false) {
     RCLCPP_INFO_STREAM(node_.get_logger(),
                        "Publishing WholeBodyState messages on "
                            << topic << " (frame: " << frame << ")");
@@ -46,19 +47,92 @@ public:
       pinocchio::Model &model,
       const std::string &topic = "/crocoddyl/whole_body_state",
       const std::string &frame = "odom")
-      : model_(model), data_(model), odom_frame_(frame),
-        a_(Eigen::VectorXd::Zero(model.nv)) {
+      : model_(model), data_(model), odom_frame_(frame), a_(model.nv),
+        is_reduced_model_(false) {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
     ROS_INFO_STREAM("Publishing WholeBodyState messages on "
                     << topic << " (frame: " << frame << ")");
 #endif
+    a_.setZero();
     pub_.msg_.header.frame_id = frame;
+  }
+
+  /**
+   * @brief Initialize the whole-body state publisher for rigid-body system
+   * with locked joints.
+   *
+   * @param[in] model          Pinocchio model
+   * @param[in] locked_joints  List of joints to be locked
+   * @param[in] qref           Reference configuration
+   * @param[in] topic          Topic name
+   * @param[in] frame          Odometry frame
+   */
+#ifdef ROS2
+  WholeBodyStateRosPublisher(
+      pinocchio::Model &model, std::vector<std::string> locked_joints,
+      const Eigen::Ref<const Eigen::VectorXd> &qref,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
+      : node_("whole_body_state_publisher"),
+        pub_(node_.create_publisher<WholeBodyState>(topic, 1)), model_(model),
+        odom_frame_(frame), a_(model.nv - locked_joints.size()), qref_(qref),
+        is_reduced_model_(true) {
+    RCLCPP_INFO_STREAM(node_.get_logger(),
+                       "Publishing WholeBodyState messages on "
+                           << topic << " (frame: " << frame << ")");
+    if (qref_.size() != model_.nq) {
+      RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")";
+    }
+#else
+  WholeBodyStateRosPublisher(
+      pinocchio::Model &model, std::vector<std::string> locked_joints,
+      const Eigen::Ref<const Eigen::VectorXd> &qref,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
+      : model_(model), odom_frame_(frame), a_(model.nv - locked_joints.size()),
+        qref_(qref), is_reduced_model_(true) {
+    ros::NodeHandle n;
+    pub_.init(n, topic, 1);
+    ROS_INFO_STREAM("Publishing WholeBodyState messages on "
+                    << topic << " (frame: " << frame << ")");
+    if (qref_.size() != model_.nq) {
+      ROS_ERROR_STREAM(
+          "Invalid argument: qref has wrong dimension (it should be "
+          << std::to_string(model_.nq) << ")");
+    }
+#endif
+    a_.setZero();
+    pub_.msg_.header.frame_id = frame;
+
+    // Build reduce model
+    for (std::string name : locked_joints) {
+      if (model_.existJointName(name)) {
+        joint_ids_.push_back(model_.getJointId(name));
+      } else {
+#ifdef ROS2
+        RCLCPP_ERROR_STREAM(node_.get_logger(),
+                            "Doesn't exist " << name << " joint");
+#else
+        ROS_ERROR_STREAM("Doesn't exist " << name << " joint");
+#endif
+      }
+    }
+    pinocchio::buildReducedModel(model_, joint_ids_, qref_, reduced_model_);
+    data_ = pinocchio::Data(reduced_model_);
+
+    const std::size_t root_joint_id = get_root_joint_id(model);
+    const std::size_t nv_root = model.joints[root_joint_id].nv();
+    qfull_ = Eigen::VectorXd::Zero(model.nq);
+    vfull_ = Eigen::VectorXd::Zero(model.nv);
+    ufull_ = Eigen::VectorXd::Zero(model.nv - nv_root);
   }
   ~WholeBodyStateRosPublisher() = default;
 
   /**
-   * @brief Publish a whole-body state ROS message
+   * @brief Publish a whole-body state ROS message.
+   * The dimension of the configuration, velocity and joint effort are defined
+   * by the rigid-body system with locked joints.
    *
    * @param t[in]    Time in secs
    * @param q[in]    Configuration vector (dimension: model.nq)
@@ -80,8 +154,15 @@ public:
           const std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
     if (pub_.trylock()) {
       pub_.msg_.header.frame_id = odom_frame_;
-      crocoddyl_msgs::toMsg(model_, data_, pub_.msg_, t, q, v, a_, tau, p, pd,
-                            f, s);
+      if (is_reduced_model_) {
+        fromReduced(model_, reduced_model_, qfull_, vfull_, ufull_, q, v, tau,
+                    qref_, joint_ids_);
+        crocoddyl_msgs::toMsg(reduced_model_, data_, pub_.msg_, t, qfull_,
+                              vfull_, a_, ufull_, p, pd, f, s);
+      } else {
+        crocoddyl_msgs::toMsg(model_, data_, pub_.msg_, t, q, v, a_, tau, p, pd,
+                              f, s);
+      }
       pub_.unlockAndPublish();
     }
   }
@@ -92,9 +173,16 @@ private:
 #endif
   realtime_tools::RealtimePublisher<WholeBodyState> pub_;
   pinocchio::Model model_;
+  pinocchio::Model reduced_model_;
   pinocchio::Data data_;
   std::string odom_frame_;
   Eigen::VectorXd a_;
+  std::vector<pinocchio::JointIndex> joint_ids_;
+  Eigen::VectorXd qref_;
+  Eigen::VectorXd qfull_;
+  Eigen::VectorXd vfull_;
+  Eigen::VectorXd ufull_;
+  bool is_reduced_model_;
 };
 
 } // namespace crocoddyl_msgs

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -177,7 +177,7 @@ private:
       pinocchio::buildReducedModel(model_, joint_ids_, qref_, reduced_model_);
       data_ = pinocchio::Data(reduced_model_);
       // Initialize the vectors and dimensions
-      const std::size_t root_joint_id = get_root_joint_id(model_);
+      const std::size_t root_joint_id = getRootJointId(model_);
       const std::size_t nv_root = model_.joints[root_joint_id].nv();
       qfull_ = Eigen::VectorXd::Zero(model_.nq);
       vfull_ = Eigen::VectorXd::Zero(model_.nv);

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -152,7 +152,7 @@ private:
       // Check the size of the reference configuration
 #ifdef ROS2
       if (qref_.size() != model_.nq) {
-        RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")";
+        RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
       }
 #else
       if (qref_.size() != model_.nq) {

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -22,7 +22,7 @@
 namespace crocoddyl_msgs {
 
 class WholeBodyStateRosPublisher {
- public:
+public:
   /**
    * @brief Initialize the whole-body state publisher
    *
@@ -31,22 +31,27 @@ class WholeBodyStateRosPublisher {
    * @param[in] frame  Odometry frame
    */
 #ifdef ROS2
-  WholeBodyStateRosPublisher(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
-                             const std::string &frame = "odom")
+  WholeBodyStateRosPublisher(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
       : node_("whole_body_state_publisher"),
-        pub_(node_.create_publisher<WholeBodyState>(topic, 1)),
-        model_(model),
-        data_(model),
-        odom_frame_(frame),
-        a_(Eigen::VectorXd::Zero(model.nv)) {
-    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing WholeBodyState messages on " << topic <<  " (frame: " << frame << ")");
+        pub_(node_.create_publisher<WholeBodyState>(topic, 1)), model_(model),
+        data_(model), odom_frame_(frame), a_(Eigen::VectorXd::Zero(model.nv)) {
+    RCLCPP_INFO_STREAM(node_.get_logger(),
+                       "Publishing WholeBodyState messages on "
+                           << topic << " (frame: " << frame << ")");
 #else
-  WholeBodyStateRosPublisher(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
-                             const std::string &frame = "odom")
-      : model_(model), data_(model), odom_frame_(frame), a_(Eigen::VectorXd::Zero(model.nv)) {
+  WholeBodyStateRosPublisher(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
+      : model_(model), data_(model), odom_frame_(frame),
+        a_(Eigen::VectorXd::Zero(model.nv)) {
     ros::NodeHandle n;
     pub_.init(n, topic, 1);
-    ROS_INFO_STREAM("Publishing WholeBodyState messages on " << topic <<  " (frame: " << frame << ")");
+    ROS_INFO_STREAM("Publishing WholeBodyState messages on "
+                    << topic << " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
   }
@@ -64,19 +69,24 @@ class WholeBodyStateRosPublisher {
    * @param f[in]    Contact force, type and status
    * @param s[in]    Contact surface and friction coefficient
    */
-  void publish(const double t, const Eigen::Ref<const Eigen::VectorXd> &q, const Eigen::Ref<const Eigen::VectorXd> &v,
-               const Eigen::Ref<const Eigen::VectorXd> &tau, const std::map<std::string, pinocchio::SE3> &p,
-               const std::map<std::string, pinocchio::Motion> &pd,
-               const std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>> &f,
-               const std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
+  void
+  publish(const double t, const Eigen::Ref<const Eigen::VectorXd> &q,
+          const Eigen::Ref<const Eigen::VectorXd> &v,
+          const Eigen::Ref<const Eigen::VectorXd> &tau,
+          const std::map<std::string, pinocchio::SE3> &p,
+          const std::map<std::string, pinocchio::Motion> &pd,
+          const std::map<std::string, std::tuple<pinocchio::Force, ContactType,
+                                                 ContactStatus>> &f,
+          const std::map<std::string, std::pair<Eigen::Vector3d, double>> &s) {
     if (pub_.trylock()) {
       pub_.msg_.header.frame_id = odom_frame_;
-      crocoddyl_msgs::toMsg(model_, data_, pub_.msg_, t, q, v, a_, tau, p, pd, f, s);
+      crocoddyl_msgs::toMsg(model_, data_, pub_.msg_, t, q, v, a_, tau, p, pd,
+                            f, s);
       pub_.unlockAndPublish();
     }
   }
 
- private:
+private:
 #ifdef ROS2
   rclcpp::Node node_;
 #endif
@@ -87,6 +97,6 @@ class WholeBodyStateRosPublisher {
   Eigen::VectorXd a_;
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_WHOLE_BODY_STATE_PUBLISHER_H_
+#endif // CROCODDYL_MSG_WHOLE_BODY_STATE_PUBLISHER_H_

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -21,13 +21,15 @@
 namespace crocoddyl_msgs {
 
 #ifdef ROS2
-typedef const whole_body_state_msgs::msg::WholeBodyState::SharedPtr WholeBodyStateSharedPtr;
+typedef const whole_body_state_msgs::msg::WholeBodyState::SharedPtr
+    WholeBodyStateSharedPtr;
 #else
-typedef const whole_body_state_msgs::WholeBodyState::ConstPtr &WholeBodyStateSharedPtr;
+typedef const whole_body_state_msgs::WholeBodyState::ConstPtr
+    &WholeBodyStateSharedPtr;
 #endif
 
 class WholeBodyStateRosSubscriber {
- public:
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /**
@@ -38,46 +40,40 @@ class WholeBodyStateRosSubscriber {
    * @param[in] frame  Odometry frame
    */
 #ifdef ROS2
-  WholeBodyStateRosSubscriber(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
-                              const std::string &frame = "odom")
+  WholeBodyStateRosSubscriber(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
       : node_(rclcpp::Node::make_shared("whole_body_state_subscriber")),
         sub_(node_->create_subscription<WholeBodyState>(
-            topic, 1, std::bind(&WholeBodyStateRosSubscriber::callback, this, std::placeholders::_1))),
-        t_(0.),
-        q_(model.nq),
-        v_(model.nv),
-        a_(model.nv),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.),
-        odom_frame_(frame),
-        model_(model),
-        data_(model) {
+            topic, 1,
+            std::bind(&WholeBodyStateRosSubscriber::callback, this,
+                      std::placeholders::_1))),
+        t_(0.), q_(model.nq), v_(model.nv), a_(model.nv), has_new_msg_(false),
+        is_processing_msg_(false), last_msg_time_(0.), odom_frame_(frame),
+        model_(model), data_(model) {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
-    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing WholeBodyState messages on " << topic);
+    RCLCPP_INFO_STREAM(node_->get_logger(),
+                       "Subscribing WholeBodyState messages on " << topic);
 #else
-  WholeBodyStateRosSubscriber(pinocchio::Model &model, const std::string &topic = "/crocoddyl/whole_body_state",
-                              const std::string &frame = "odom")
-      : spinner_(2),
-        t_(0.),
-        q_(model.nq),
-        v_(model.nv),
-        a_(model.nv),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.),
-        odom_frame_(frame),
-        model_(model),
-        data_(model) {
+  WholeBodyStateRosSubscriber(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_state",
+      const std::string &frame = "odom")
+      : spinner_(2), t_(0.), q_(model.nq), v_(model.nv), a_(model.nv),
+        has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.),
+        odom_frame_(frame), model_(model), data_(model) {
     ros::NodeHandle n;
-    sub_ = n.subscribe<WholeBodyState>(topic, 1, &WholeBodyStateRosSubscriber::callback, this,
-                                       ros::TransportHints().tcpNoDelay());
+    sub_ = n.subscribe<WholeBodyState>(
+        topic, 1, &WholeBodyStateRosSubscriber::callback, this,
+        ros::TransportHints().tcpNoDelay());
     spinner_.start();
     ROS_INFO_STREAM("Subscribing WholeBodyState messages on " << topic);
 #endif
-    const std::size_t root_joint_id = model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
+    const std::size_t root_joint_id =
+        model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
     const std::size_t njoints = model.nv - model.joints[root_joint_id].nv();
     q_.setZero();
     v_.setZero();
@@ -100,23 +96,27 @@ class WholeBodyStateRosSubscriber {
   std::tuple<double, Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd,
              std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>>,
              std::map<std::string, Eigen::VectorXd>,
-             std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>,
+             std::map<std::string,
+                      std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>,
              std::map<std::string, std::pair<Eigen::Vector3d, double>>>
   get_state() {
     // start processing the message
     is_processing_msg_ = true;
     std::lock_guard<std::mutex> guard(mutex_);
-    crocoddyl_msgs::fromMsg(model_, data_, msg_, t_, q_, v_, a_, tau_, p_, pd_, f_, s_);
+    crocoddyl_msgs::fromMsg(model_, data_, msg_, t_, q_, v_, a_, tau_, p_, pd_,
+                            f_, s_);
     // create maps that do not depend on Pinocchio objects
     for (auto it = p_.cbegin(); it != p_.cend(); ++it) {
-      p_tmp_[it->first] = std::make_pair(it->second.translation(), it->second.rotation());
+      p_tmp_[it->first] =
+          std::make_pair(it->second.translation(), it->second.rotation());
     }
     for (auto it = pd_.cbegin(); it != pd_.cend(); ++it) {
       pd_tmp_[it->first] = it->second.toVector();
     }
     for (auto it = f_.cbegin(); it != f_.cend(); ++it) {
       f_tmp_[it->first] =
-          std::make_tuple(std::get<0>(it->second).toVector(), std::get<1>(it->second), std::get<2>(it->second));
+          std::make_tuple(std::get<0>(it->second).toVector(),
+                          std::get<1>(it->second), std::get<2>(it->second));
     }
     // finish processing the message
     is_processing_msg_ = false;
@@ -129,31 +129,33 @@ class WholeBodyStateRosSubscriber {
    */
   bool has_new_msg() const { return has_new_msg_; }
 
- private:
+private:
 #ifdef ROS2
   std::shared_ptr<rclcpp::Node> node_;
   rclcpp::executors::SingleThreadedExecutor spinner_;
   std::thread thread_;
   void spin() { spinner_.spin(); }
-  rclcpp::Subscription<WholeBodyState>::SharedPtr sub_;  //!< ROS subscriber
+  rclcpp::Subscription<WholeBodyState>::SharedPtr sub_; //!< ROS subscriber
 #else
   ros::AsyncSpinner spinner_;
-  ros::Subscriber sub_;  //!< ROS subscriber
+  ros::Subscriber sub_; //!< ROS subscriber
 #endif
-  std::mutex mutex_;                             ///< Mutex to prevent race condition on callback
-  WholeBodyState msg_;                           //!< ROS message
-  double t_;                                     //!< Time at the beginning of the interval
-  Eigen::VectorXd q_;                            ///< Configuration vector (size nq)
-  Eigen::VectorXd v_;                            ///< Tangent vector (size nv)
-  Eigen::VectorXd a_;                            ///< System acceleration vector (size nv)
-  Eigen::VectorXd tau_;                          ///< Torque vector (size njoints)
-  std::map<std::string, pinocchio::SE3> p_;      //!< Contact position
-  std::map<std::string, pinocchio::Motion> pd_;  //!< Contact velocity
-  std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>>
-      f_;                                                        //!< Contact force, type and status
-  std::map<std::string, std::pair<Eigen::Vector3d, double>> s_;  //!< Contact surface and friction coefficient
-  bool has_new_msg_;                                             //!< Indcate when a new message has been received
-  bool is_processing_msg_;                                       //!< Indicate when we are processing the message
+  std::mutex mutex_;    ///< Mutex to prevent race condition on callback
+  WholeBodyState msg_;  //!< ROS message
+  double t_;            //!< Time at the beginning of the interval
+  Eigen::VectorXd q_;   ///< Configuration vector (size nq)
+  Eigen::VectorXd v_;   ///< Tangent vector (size nv)
+  Eigen::VectorXd a_;   ///< System acceleration vector (size nv)
+  Eigen::VectorXd tau_; ///< Torque vector (size njoints)
+  std::map<std::string, pinocchio::SE3> p_;     //!< Contact position
+  std::map<std::string, pinocchio::Motion> pd_; //!< Contact velocity
+  std::map<std::string,
+           std::tuple<pinocchio::Force, ContactType, ContactStatus>>
+      f_; //!< Contact force, type and status
+  std::map<std::string, std::pair<Eigen::Vector3d, double>>
+      s_;                  //!< Contact surface and friction coefficient
+  bool has_new_msg_;       //!< Indcate when a new message has been received
+  bool is_processing_msg_; //!< Indicate when we are processing the message
   double last_msg_time_;
   std::string odom_frame_;
   pinocchio::Model model_;
@@ -162,14 +164,17 @@ class WholeBodyStateRosSubscriber {
   // in Pinocchio
   std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>> p_tmp_;
   std::map<std::string, Eigen::VectorXd> pd_tmp_;
-  std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>> f_tmp_;
+  std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>
+      f_tmp_;
   void callback(WholeBodyStateSharedPtr msg) {
     if (msg->header.frame_id != odom_frame_) {
 #ifdef ROS2
-      RCLCPP_ERROR_STREAM(node_->get_logger(), "Error: the whole-body state is not expressed in "
-                                                   << odom_frame_ << " (i.e., 'odom_frame')");
+      RCLCPP_ERROR_STREAM(node_->get_logger(),
+                          "Error: the whole-body state is not expressed in "
+                              << odom_frame_ << " (i.e., 'odom_frame')");
 #else
-      ROS_ERROR_STREAM("Error: the whole-body state is not expressed in " << odom_frame_ << " (i.e., 'odom_frame')");
+      ROS_ERROR_STREAM("Error: the whole-body state is not expressed in "
+                       << odom_frame_ << " (i.e., 'odom_frame')");
 #endif
       return;
     }
@@ -188,17 +193,20 @@ class WholeBodyStateRosSubscriber {
         last_msg_time_ = t;
       } else {
 #ifdef ROS2
-        RCLCPP_WARN_STREAM(node_->get_logger(), "Out of order message. Last timestamp: "
-                                                    << std::fixed << last_msg_time_ << ", current timestamp: " << t);
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+                           "Out of order message. Last timestamp: "
+                               << std::fixed << last_msg_time_
+                               << ", current timestamp: " << t);
 #else
-        ROS_WARN_STREAM("Out of order message. Last timestamp: " << std::fixed << last_msg_time_
-                                                                 << ", current timestamp: " << t);
+        ROS_WARN_STREAM("Out of order message. Last timestamp: "
+                        << std::fixed << last_msg_time_
+                        << ", current timestamp: " << t);
 #endif
       }
     }
   }
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_WHOLE_BODY_STATE_SUBSCRIBER_H_
+#endif // CROCODDYL_MSG_WHOLE_BODY_STATE_SUBSCRIBER_H_

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -72,8 +72,7 @@ public:
     spinner_.start();
     ROS_INFO_STREAM("Subscribing WholeBodyState messages on " << topic);
 #endif
-    const std::size_t root_joint_id =
-        model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
+    const std::size_t root_joint_id = get_root_joint_id(model);
     const std::size_t njoints = model.nv - model.joints[root_joint_id].nv();
     q_.setZero();
     v_.setZero();

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -227,7 +227,7 @@ private:
       // Check the size of the reference configuration
 #ifdef ROS2
       if (qref_.size() != model_.nq) {
-        RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")";
+        RCLCPP_ERROR_STREAM(node_->get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
       }
 #else
       if (qref_.size() != model_.nq) {
@@ -242,7 +242,7 @@ private:
           joint_ids_.push_back(model_.getJointId(name));
         } else {
 #ifdef ROS2
-          RCLCPP_ERROR_STREAM(node_.get_logger(),
+          RCLCPP_ERROR_STREAM(node_->get_logger(),
                               "Doesn't exist " << name << " joint");
 #else
           ROS_ERROR_STREAM("Doesn't exist " << name << " joint");

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -222,7 +222,7 @@ private:
       f_tmp_;
 
   void init(const std::vector<std::string> &locked_joints = DEFAULT_VECTOR) {
-    const std::size_t root_joint_id = get_root_joint_id(model_);
+    const std::size_t root_joint_id = getRootJointId(model_);
     const std::size_t nv_root = model_.joints[root_joint_id].nv();
     if (locked_joints.size() != 0) {
       // Check the size of the reference configuration

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -230,7 +230,7 @@ private:
       pinocchio::buildReducedModel(model_, joint_ids_, qref_, reduced_model_);
       data_ = pinocchio::Data(reduced_model_);
       // Initialize the vectors and dimensions
-      const std::size_t root_joint_id = get_root_joint_id(model_);
+      const std::size_t root_joint_id = getRootJointId(model_);
       const std::size_t nv_root = model_.joints[root_joint_id].nv();
       qfull_ = Eigen::VectorXd::Zero(model_.nq);
       vfull_ = Eigen::VectorXd::Zero(model_.nv);

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -74,13 +74,13 @@ public:
 #ifdef ROS2
       : node_("whole_body_trajectory_publisher"),
         pub_(node_.create_publisher<WholeBodyTrajectory>(topic, queue)),
-        model_(model), odom_frame_(frame), a_(model.nv - locked_joints.size()),
+        model_(model), data_(model), odom_frame_(frame), a_(model.nv),
         qref_(qref), is_reduced_model_(true) {
     RCLCPP_INFO_STREAM(node_.get_logger(),
                        "Publishing WholeBodyTrajectory messages on "
                            << topic << " (frame: " << frame << ")");
 #else
-      : model_(model), odom_frame_(frame), a_(model.nv - locked_joints.size()),
+      : model_(model), data_(model), odom_frame_(frame), a_(model.nv),
         qref_(qref), is_reduced_model_(true) {
     ros::NodeHandle n;
     pub_.init(n, topic, queue);
@@ -159,7 +159,7 @@ public:
           fromReduced(model_, reduced_model_, qfull_, vfull_, ufull_,
                       xs[i].head(reduced_model_.nq),
                       xs[i].tail(reduced_model_.nv), us[i], qref_, joint_ids_);
-          crocoddyl_msgs::toMsg(reduced_model_, data_, pub_.msg_.trajectory[i],
+          crocoddyl_msgs::toMsg(model_, data_, pub_.msg_.trajectory[i],
                                 ts[i], qfull_, vfull_, a_, ufull_, ps[i],
                                 pds[i], fs[i], ss[i]);
         } else {
@@ -228,7 +228,7 @@ private:
         }
       }
       pinocchio::buildReducedModel(model_, joint_ids_, qref_, reduced_model_);
-      data_ = pinocchio::Data(reduced_model_);
+
       // Initialize the vectors and dimensions
       const std::size_t root_joint_id = getRootJointId(model_);
       const std::size_t nv_root = model_.joints[root_joint_id].nv();

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -22,7 +22,7 @@
 namespace crocoddyl_msgs {
 
 class WholeBodyTrajectoryRosPublisher {
- public:
+public:
   /**
    * @brief Initialize the whole-body trajectory publisher
    *
@@ -32,24 +32,26 @@ class WholeBodyTrajectoryRosPublisher {
    * @param[in] queue  Queue size
    */
 #ifdef ROS2
-  WholeBodyTrajectoryRosPublisher(pinocchio::Model &model,
-                                  const std::string &topic = "/crocoddyl/whole_body_trajectory",
-                                  const std::string &frame = "odom", int queue = 10)
+  WholeBodyTrajectoryRosPublisher(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_trajectory",
+      const std::string &frame = "odom", int queue = 10)
       : node_("whole_body_trajectory_publisher"),
         pub_(node_.create_publisher<WholeBodyTrajectory>(topic, queue)),
-        model_(model),
-        data_(model),
-        odom_frame_(frame),
-        a_null_(model.nv) {
-    RCLCPP_INFO_STREAM(node_.get_logger(), "Publishing WholeBodyTrajectory messages on " << topic <<  " (frame: " << frame << ")");
+        model_(model), data_(model), odom_frame_(frame), a_null_(model.nv) {
+    RCLCPP_INFO_STREAM(node_.get_logger(),
+                       "Publishing WholeBodyTrajectory messages on "
+                           << topic << " (frame: " << frame << ")");
 #else
-  WholeBodyTrajectoryRosPublisher(pinocchio::Model &model,
-                                  const std::string &topic = "/crocoddyl/whole_body_trajectory",
-                                  const std::string &frame = "odom", int queue = 10)
+  WholeBodyTrajectoryRosPublisher(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_trajectory",
+      const std::string &frame = "odom", int queue = 10)
       : model_(model), data_(model), odom_frame_(frame), a_null_(model.nv) {
     ros::NodeHandle n;
     pub_.init(n, topic, queue);
-    ROS_INFO_STREAM("Publishing WholeBodyTrajectory messages on " << topic <<  " (frame: " << frame << ")");
+    ROS_INFO_STREAM("Publishing WholeBodyTrajectory messages on "
+                    << topic << " (frame: " << frame << ")");
 #endif
     pub_.msg_.header.frame_id = frame;
     a_null_.setZero();
@@ -67,16 +69,20 @@ class WholeBodyTrajectoryRosPublisher {
    * @param fs[in]   Vector of contact forces, types and statuses
    * @param ss[in]   Vector of contact surfaces and friction coefficients
    */
-  void publish(const std::vector<double> &ts, const std::vector<Eigen::VectorXd> &xs,
-               const std::vector<Eigen::VectorXd> &us, const std::vector<std::map<std::string, pinocchio::SE3>> &ps,
-               const std::vector<std::map<std::string, pinocchio::Motion>> &pds,
-               const std::vector<std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>>> &fs,
-               const std::vector<std::map<std::string, std::pair<Eigen::Vector3d, double>>> &ss) {
+  void
+  publish(const std::vector<double> &ts, const std::vector<Eigen::VectorXd> &xs,
+          const std::vector<Eigen::VectorXd> &us,
+          const std::vector<std::map<std::string, pinocchio::SE3>> &ps,
+          const std::vector<std::map<std::string, pinocchio::Motion>> &pds,
+          const std::vector<
+              std::map<std::string, std::tuple<pinocchio::Force, ContactType,
+                                               ContactStatus>>> &fs,
+          const std::vector<
+              std::map<std::string, std::pair<Eigen::Vector3d, double>>> &ss) {
     if (pub_.trylock()) {
       if (ts.size() != xs.size()) {
-        throw std::invalid_argument(
-            "The size of the ts vector needs to equal "
-            "the size of the xs vector.");
+        throw std::invalid_argument("The size of the ts vector needs to equal "
+                                    "the size of the xs vector.");
       }
       if (ts.size() != us.size()) {
         throw std::invalid_argument(
@@ -89,10 +95,9 @@ class WholeBodyTrajectoryRosPublisher {
             "the ts vector.");
       }
       if (ts.size() != pds.size()) {
-        throw std::invalid_argument(
-            "If provided, the size of the pds vector "
-            "needs to equal the size of "
-            "the ts vector.");
+        throw std::invalid_argument("If provided, the size of the pds vector "
+                                    "needs to equal the size of "
+                                    "the ts vector.");
       }
       if (ts.size() != fs.size()) {
         throw std::invalid_argument(
@@ -113,20 +118,24 @@ class WholeBodyTrajectoryRosPublisher {
       pub_.msg_.trajectory.resize(ts.size());
       for (std::size_t i = 0; i < ts.size(); ++i) {
         pub_.msg_.trajectory[i].header.frame_id = odom_frame_;
-        crocoddyl_msgs::toMsg(model_, data_, pub_.msg_.trajectory[i], ts[i], xs[i].head(model_.nq),
-                              xs[i].tail(model_.nv), a_null_, us[i], ps[i], pds[i], fs[i], ss[i]);
+        crocoddyl_msgs::toMsg(model_, data_, pub_.msg_.trajectory[i], ts[i],
+                              xs[i].head(model_.nq), xs[i].tail(model_.nv),
+                              a_null_, us[i], ps[i], pds[i], fs[i], ss[i]);
       }
       pub_.unlockAndPublish();
     } else {
 #ifdef ROS2
-      RCLCPP_WARN_STREAM(node_.get_logger(), "[publish] Could not lock publisher, not published feedback policy");
+      RCLCPP_WARN_STREAM(
+          node_.get_logger(),
+          "[publish] Could not lock publisher, not published feedback policy");
 #else
-      ROS_WARN_STREAM("[publish] Could not lock publisher, not published feedback policy");
+      ROS_WARN_STREAM(
+          "[publish] Could not lock publisher, not published feedback policy");
 #endif
     }
   }
 
- private:
+private:
 #ifdef ROS2
   rclcpp::Node node_;
 #endif
@@ -137,6 +146,6 @@ class WholeBodyTrajectoryRosPublisher {
   Eigen::VectorXd a_null_;
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_WHOLE_BODY_TRAJECTORY_PUBLISHER_H_
+#endif // CROCODDYL_MSG_WHOLE_BODY_TRAJECTORY_PUBLISHER_H_

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -205,7 +205,7 @@ private:
       // Check the size of the reference configuration
 #ifdef ROS2
       if (qref_.size() != model_.nq) {
-        RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")";
+        RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
       }
 #else
       if (qref_.size() != model_.nq) {

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -28,8 +28,6 @@ typedef const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr
     &WholeBodyTrajectorySharedPtr;
 #endif
 
-static std::vector<std::string> DEFAULT_VECTOR;
-
 class WholeBodyTrajectoryRosSubscriber {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -260,7 +260,7 @@ private:
       // Check the size of the reference configuration
       if (qref_.size() != model_.nq) {
 #ifdef ROS2
-        RCLCPP_ERROR_STREAM(node_->get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")";
+        RCLCPP_ERROR_STREAM(node_->get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
 #else
         ROS_ERROR_STREAM(
             "Invalid argument: qref has wrong dimension (it should be "

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -256,7 +256,7 @@ private:
     spinner_.start();
 #endif
 
-    const std::size_t root_joint_id = get_root_joint_id(model_);
+    const std::size_t root_joint_id = getRootJointId(model_);
     const std::size_t nv_root = model_.joints[root_joint_id].nv();
     if (locked_joints.size() != 0) {
       // Check the size of the reference configuration

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -72,8 +72,7 @@ public:
     ROS_INFO_STREAM("Subscribing WholeBodyTrajectory messages on " << topic);
 #endif
     a_null_.setZero();
-    const std::size_t root_joint_id =
-        model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
+    const std::size_t root_joint_id = get_root_joint_id(model);
     nx_ = model_.nq + model_.nv;
     nu_ = model.nv - model.joints[root_joint_id].nv();
   }

--- a/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_subscriber.h
@@ -21,13 +21,15 @@
 namespace crocoddyl_msgs {
 
 #ifdef ROS2
-typedef const whole_body_state_msgs::msg::WholeBodyTrajectory::SharedPtr WholeBodyTrajectorySharedPtr;
+typedef const whole_body_state_msgs::msg::WholeBodyTrajectory::SharedPtr
+    WholeBodyTrajectorySharedPtr;
 #else
-typedef const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr &WholeBodyTrajectorySharedPtr;
+typedef const whole_body_state_msgs::WholeBodyTrajectory::ConstPtr
+    &WholeBodyTrajectorySharedPtr;
 #endif
 
 class WholeBodyTrajectoryRosSubscriber {
- public:
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /**
@@ -38,43 +40,40 @@ class WholeBodyTrajectoryRosSubscriber {
    * @param[in] frame  Odometry frame
    */
 #ifdef ROS2
-  WholeBodyTrajectoryRosSubscriber(pinocchio::Model &model,
-                                   const std::string &topic = "/crocoddyl/whole_body_trajectory",
-                                   const std::string &frame = "odom")
+  WholeBodyTrajectoryRosSubscriber(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_trajectory",
+      const std::string &frame = "odom")
       : node_(rclcpp::Node::make_shared("whole_body_trajectory_subscriber")),
         sub_(node_->create_subscription<WholeBodyTrajectory>(
-            topic, 1, std::bind(&WholeBodyTrajectoryRosSubscriber::callback, this, std::placeholders::_1))),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.),
-        odom_frame_(frame),
-        model_(model),
-        data_(model),
-        a_null_(model.nv) {
+            topic, 1,
+            std::bind(&WholeBodyTrajectoryRosSubscriber::callback, this,
+                      std::placeholders::_1))),
+        has_new_msg_(false), is_processing_msg_(false), last_msg_time_(0.),
+        odom_frame_(frame), model_(model), data_(model), a_null_(model.nv) {
     spinner_.add_node(node_);
     thread_ = std::thread([this]() { this->spin(); });
     thread_.detach();
-    RCLCPP_INFO_STREAM(node_->get_logger(), "Subscribing WholeBodyTrajectory messages on " << topic);
+    RCLCPP_INFO_STREAM(node_->get_logger(),
+                       "Subscribing WholeBodyTrajectory messages on " << topic);
 #else
-  WholeBodyTrajectoryRosSubscriber(pinocchio::Model &model,
-                                   const std::string &topic = "/crocoddyl/whole_body_trajectory",
-                                   const std::string &frame = "odom")
-      : spinner_(2),
-        has_new_msg_(false),
-        is_processing_msg_(false),
-        last_msg_time_(0.),
-        odom_frame_(frame),
-        model_(model),
-        data_(model),
+  WholeBodyTrajectoryRosSubscriber(
+      pinocchio::Model &model,
+      const std::string &topic = "/crocoddyl/whole_body_trajectory",
+      const std::string &frame = "odom")
+      : spinner_(2), has_new_msg_(false), is_processing_msg_(false),
+        last_msg_time_(0.), odom_frame_(frame), model_(model), data_(model),
         a_null_(model.nv) {
     ros::NodeHandle n;
-    sub_ = n.subscribe<WholeBodyTrajectory>(topic, 1, &WholeBodyTrajectoryRosSubscriber::callback, this,
-                                            ros::TransportHints().tcpNoDelay());
+    sub_ = n.subscribe<WholeBodyTrajectory>(
+        topic, 1, &WholeBodyTrajectoryRosSubscriber::callback, this,
+        ros::TransportHints().tcpNoDelay());
     spinner_.start();
     ROS_INFO_STREAM("Subscribing WholeBodyTrajectory messages on " << topic);
 #endif
     a_null_.setZero();
-    const std::size_t root_joint_id = model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
+    const std::size_t root_joint_id =
+        model.existJointName("root_joint") ? model.getJointId("root_joint") : 0;
     nx_ = model_.nq + model_.nv;
     nu_ = model.nv - model.joints[root_joint_id].nv();
   }
@@ -88,11 +87,15 @@ class WholeBodyTrajectoryRosSubscriber {
    * velocities, contact forces (wrench, type and status), and contact surface
    * and friction coefficients.
    */
-  std::tuple<std::vector<double>, std::vector<Eigen::VectorXd>, std::vector<Eigen::VectorXd>,
-             std::vector<std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>>>,
-             std::vector<std::map<std::string, Eigen::VectorXd>>,
-             std::vector<std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>>,
-             std::vector<std::map<std::string, std::pair<Eigen::Vector3d, double>>>>
+  std::tuple<
+      std::vector<double>, std::vector<Eigen::VectorXd>,
+      std::vector<Eigen::VectorXd>,
+      std::vector<
+          std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>>>,
+      std::vector<std::map<std::string, Eigen::VectorXd>>,
+      std::vector<std::map<std::string, std::tuple<Eigen::VectorXd, ContactType,
+                                                   ContactStatus>>>,
+      std::vector<std::map<std::string, std::pair<Eigen::Vector3d, double>>>>
   get_trajectory() {
     // start processing the message
     is_processing_msg_ = true;
@@ -109,14 +112,16 @@ class WholeBodyTrajectoryRosSubscriber {
     for (std::size_t i = 0; i < N; ++i) {
       xs_[i].resize(nx_);
       us_[i].resize(nu_);
-      crocoddyl_msgs::fromMsg(model_, data_, msg_.trajectory[i], ts_[i], xs_[i].head(model_.nq),
-                              xs_[i].tail(model_.nv), a_null_, us_[i], ps_[i], pds_[i], fs_[i], ss_[i]);
+      crocoddyl_msgs::fromMsg(model_, data_, msg_.trajectory[i], ts_[i],
+                              xs_[i].head(model_.nq), xs_[i].tail(model_.nv),
+                              a_null_, us_[i], ps_[i], pds_[i], fs_[i], ss_[i]);
       // create maps that do not depend on Pinocchio objects
       ps_tmp_.resize(N);
       pds_tmp_.resize(N);
       fs_tmp_.resize(N);
       for (auto it = ps_[i].cbegin(); it != ps_[i].cend(); ++it) {
-        p_tmp_[it->first] = std::make_pair(it->second.translation(), it->second.rotation());
+        p_tmp_[it->first] =
+            std::make_pair(it->second.translation(), it->second.rotation());
       }
       ps_tmp_[i] = p_tmp_;
       for (auto it = pds_[i].cbegin(); it != pds_[i].cend(); ++it) {
@@ -125,7 +130,8 @@ class WholeBodyTrajectoryRosSubscriber {
       pds_tmp_[i] = pd_tmp_;
       for (auto it = fs_[i].cbegin(); it != fs_[i].cend(); ++it) {
         f_tmp_[it->first] =
-            std::make_tuple(std::get<0>(it->second).toVector(), std::get<1>(it->second), std::get<2>(it->second));
+            std::make_tuple(std::get<0>(it->second).toVector(),
+                            std::get<1>(it->second), std::get<2>(it->second));
       }
       fs_tmp_[i] = f_tmp_;
     }
@@ -140,30 +146,33 @@ class WholeBodyTrajectoryRosSubscriber {
    */
   bool has_new_msg() const { return has_new_msg_; }
 
- private:
+private:
 #ifdef ROS2
   std::shared_ptr<rclcpp::Node> node_;
   rclcpp::executors::SingleThreadedExecutor spinner_;
   std::thread thread_;
   void spin() { spinner_.spin(); }
-  rclcpp::Subscription<WholeBodyTrajectory>::SharedPtr sub_;  //!< ROS subscriber
+  rclcpp::Subscription<WholeBodyTrajectory>::SharedPtr sub_; //!< ROS subscriber
 #else
   ros::AsyncSpinner spinner_;
-  ros::Subscriber sub_;  //!< ROS subscriber
+  ros::Subscriber sub_; //!< ROS subscriber
 #endif
-  std::mutex mutex_;                                           ///< Mutex to prevent race condition on callback
-  WholeBodyTrajectory msg_;                                    //!< ROS message
-  std::vector<double> ts_;                                     //!< Vector of time at the beginning of the interval
-  std::vector<Eigen::VectorXd> xs_;                            ///< Vector of states
-  std::vector<Eigen::VectorXd> us_;                            ///< Vector of joint efforts
-  std::vector<std::map<std::string, pinocchio::SE3>> ps_;      //!< Vector of contact positions
-  std::vector<std::map<std::string, pinocchio::Motion>> pds_;  //!< Vector of contact velocities
-  std::vector<std::map<std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>>>
-      fs_;  //!< Vector of contact forces, types and statuses
+  std::mutex mutex_;        ///< Mutex to prevent race condition on callback
+  WholeBodyTrajectory msg_; //!< ROS message
+  std::vector<double> ts_;  //!< Vector of time at the beginning of the interval
+  std::vector<Eigen::VectorXd> xs_; ///< Vector of states
+  std::vector<Eigen::VectorXd> us_; ///< Vector of joint efforts
+  std::vector<std::map<std::string, pinocchio::SE3>>
+      ps_; //!< Vector of contact positions
+  std::vector<std::map<std::string, pinocchio::Motion>>
+      pds_; //!< Vector of contact velocities
+  std::vector<std::map<
+      std::string, std::tuple<pinocchio::Force, ContactType, ContactStatus>>>
+      fs_; //!< Vector of contact forces, types and statuses
   std::vector<std::map<std::string, std::pair<Eigen::Vector3d, double>>>
-      ss_;                  //!< Vector of contact surfaces and friction coefficients
-  bool has_new_msg_;        //!< Indcate when a new message has been received
-  bool is_processing_msg_;  //!< Indicate when we are processing the message
+      ss_;           //!< Vector of contact surfaces and friction coefficients
+  bool has_new_msg_; //!< Indcate when a new message has been received
+  bool is_processing_msg_; //!< Indicate when we are processing the message
   double last_msg_time_;
   std::string odom_frame_;
   pinocchio::Model model_;
@@ -175,18 +184,25 @@ class WholeBodyTrajectoryRosSubscriber {
   // in Pinocchio
   std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>> p_tmp_;
   std::map<std::string, Eigen::VectorXd> pd_tmp_;
-  std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>> f_tmp_;
-  std::vector<std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>>> ps_tmp_;
+  std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>
+      f_tmp_;
+  std::vector<
+      std::map<std::string, std::pair<Eigen::Vector3d, Eigen::MatrixXd>>>
+      ps_tmp_;
   std::vector<std::map<std::string, Eigen::VectorXd>> pds_tmp_;
-  std::vector<std::map<std::string, std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>> fs_tmp_;
+  std::vector<std::map<std::string,
+                       std::tuple<Eigen::VectorXd, ContactType, ContactStatus>>>
+      fs_tmp_;
   void callback(WholeBodyTrajectorySharedPtr msg) {
     if (msg->header.frame_id != odom_frame_) {
 #ifdef ROS2
-      RCLCPP_ERROR_STREAM(node_->get_logger(), "Error: the whole-body trajectory is not expressed in "
-                                                   << odom_frame_ << " (i.e., 'odom_frame')");
+      RCLCPP_ERROR_STREAM(
+          node_->get_logger(),
+          "Error: the whole-body trajectory is not expressed in "
+              << odom_frame_ << " (i.e., 'odom_frame')");
 #else
-      ROS_ERROR_STREAM("Error: the whole-body trajectory is not expressed in " << odom_frame_
-                                                                               << " (i.e., 'odom_frame')");
+      ROS_ERROR_STREAM("Error: the whole-body trajectory is not expressed in "
+                       << odom_frame_ << " (i.e., 'odom_frame')");
 #endif
       return;
     }
@@ -205,17 +221,20 @@ class WholeBodyTrajectoryRosSubscriber {
         last_msg_time_ = t;
       } else {
 #ifdef ROS2
-        RCLCPP_WARN_STREAM(node_->get_logger(), "Out of order message. Last timestamp: "
-                                                    << std::fixed << last_msg_time_ << ", current timestamp: " << t);
+        RCLCPP_WARN_STREAM(node_->get_logger(),
+                           "Out of order message. Last timestamp: "
+                               << std::fixed << last_msg_time_
+                               << ", current timestamp: " << t);
 #else
-        ROS_WARN_STREAM("Out of order message. Last timestamp: " << std::fixed << last_msg_time_
-                                                                 << ", current timestamp: " << t);
+        ROS_WARN_STREAM("Out of order message. Last timestamp: "
+                        << std::fixed << last_msg_time_
+                        << ", current timestamp: " << t);
 #endif
       }
     }
   }
 };
 
-}  // namespace crocoddyl_msgs
+} // namespace crocoddyl_msgs
 
-#endif  // CROCODDYL_MSG_WHOLE_BODY_TRAJECTORY_SUBSCRIBER_H_
+#endif // CROCODDYL_MSG_WHOLE_BODY_TRAJECTORY_SUBSCRIBER_H_

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>crocoddyl_msgs</name>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <description>
     Message structures needed to interact with Crocoddyl solvers, inputs and outputs. Compatibility with ROS1 and ROS2.
   </description>

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -37,13 +37,13 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
   ros::init(argc, argv, "crocoddyl_ros", ros::init_options::AnonymousName);
 #endif
 
-  m.doc() =
-      "Python interface for publishing and subscribing efficiently to "
-      "Crocoddyl messages in ROS.";
+  m.doc() = "Python interface for publishing and subscribing efficiently to "
+            "Crocoddyl messages in ROS.";
 
   py::enum_<ControlType>(m, "ControlType")
       .value("EFFORT", ControlType::EFFORT)
-      .value("ACCELERATION_CONTACTFORCE", ControlType::ACCELERATION_CONTACTFORCE)
+      .value("ACCELERATION_CONTACTFORCE",
+             ControlType::ACCELERATION_CONTACTFORCE)
       .export_values();
 
   py::enum_<ControlParametrization>(m, "ControlParametrization")
@@ -64,9 +64,11 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
       .value("SLIPPING", ContactStatus::SLIPPING)
       .export_values();
 
-  py::class_<SolverStatisticsRosPublisher, std::unique_ptr<SolverStatisticsRosPublisher, py::nodelete>>(
+  py::class_<SolverStatisticsRosPublisher,
+             std::unique_ptr<SolverStatisticsRosPublisher, py::nodelete>>(
       m, "SolverStatisticsRosPublisher")
-      .def(py::init<const std::string &>(), py::arg("topic") = "/crocoddyl/solver_statistics")
+      .def(py::init<const std::string &>(),
+           py::arg("topic") = "/crocoddyl/solver_statistics")
       .def("publish", &SolverStatisticsRosPublisher::publish,
            "Publish a solver statistic ROS message.\n\n"
            ":param iterations: number of solver iterations\n"
@@ -80,23 +82,29 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            "(default 0)\n"
            ":param inequality_feasibility: inequality constraints feasibility "
            "(default 0)",
-           py::arg("iterations"), py::arg("total_time"), py::arg("solve_time"), py::arg("cost"),
-           py::arg("regularization"), py::arg("step_length"), py::arg("dynamic_feasibility"),
-           py::arg("equality_feasibility") = 0., py::arg("inequality_feasibility") = 0.);
+           py::arg("iterations"), py::arg("total_time"), py::arg("solve_time"),
+           py::arg("cost"), py::arg("regularization"), py::arg("step_length"),
+           py::arg("dynamic_feasibility"), py::arg("equality_feasibility") = 0.,
+           py::arg("inequality_feasibility") = 0.);
 
-  py::class_<SolverStatisticsRosSubscriber, std::unique_ptr<SolverStatisticsRosSubscriber, py::nodelete>>(
+  py::class_<SolverStatisticsRosSubscriber,
+             std::unique_ptr<SolverStatisticsRosSubscriber, py::nodelete>>(
       m, "SolverStatisticsRosSubscriber")
-      .def(py::init<const std::string &>(), py::arg("topic") = "/crocoddyl/solver_statistics")
-      .def("get_solver_statistics", &SolverStatisticsRosSubscriber::get_solver_statistics,
+      .def(py::init<const std::string &>(),
+           py::arg("topic") = "/crocoddyl/solver_statistics")
+      .def("get_solver_statistics",
+           &SolverStatisticsRosSubscriber::get_solver_statistics,
            "Get the latest solver statistic.\n\n"
            ":return: a list with the number of iterations, total time, solve\n"
            "time, cost, regularization, step legth, dynamic, equality and\n"
            "inequality feasibilities.")
       .def("has_new_msg", &SolverStatisticsRosSubscriber::has_new_msg);
 
-  py::class_<SolverTrajectoryRosPublisher, std::unique_ptr<SolverTrajectoryRosPublisher, py::nodelete>>(
+  py::class_<SolverTrajectoryRosPublisher,
+             std::unique_ptr<SolverTrajectoryRosPublisher, py::nodelete>>(
       m, "SolverTrajectoryRosPublisher")
-      .def(py::init<const std::string &, const std::string &>(), py::arg("topic") = "/crocoddyl/solver_trajectory",
+      .def(py::init<const std::string &, const std::string &>(),
+           py::arg("topic") = "/crocoddyl/solver_trajectory",
            py::arg("frame") = "odom")
       .def("publish", &SolverTrajectoryRosPublisher::publish,
            "Publish a solver trajectory ROS message.\n\n"
@@ -109,13 +117,18 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            ":param types: list of control types\n"
            ":param params: list of control parametrizations",
            py::arg("ts"), py::arg("dts"), py::arg("xs"), py::arg("dxs"),
-           py::arg("us") = std::vector<Eigen::VectorXd>(), py::arg("Ks") = std::vector<Eigen::MatrixXd>(),
-           py::arg("types") = std::vector<ControlType>(), py::arg("params") = std::vector<ControlParametrization>());
+           py::arg("us") = std::vector<Eigen::VectorXd>(),
+           py::arg("Ks") = std::vector<Eigen::MatrixXd>(),
+           py::arg("types") = std::vector<ControlType>(),
+           py::arg("params") = std::vector<ControlParametrization>());
 
-  py::class_<SolverTrajectoryRosSubscriber, std::unique_ptr<SolverTrajectoryRosSubscriber, py::nodelete>>(
+  py::class_<SolverTrajectoryRosSubscriber,
+             std::unique_ptr<SolverTrajectoryRosSubscriber, py::nodelete>>(
       m, "SolverTrajectoryRosSubscriber")
-      .def(py::init<const std::string &>(), py::arg("topic") = "/crocoddyl/solver_trajectory")
-      .def("get_solver_trajectory", &SolverTrajectoryRosSubscriber::get_solver_trajectory,
+      .def(py::init<const std::string &>(),
+           py::arg("topic") = "/crocoddyl/solver_trajectory")
+      .def("get_solver_trajectory",
+           &SolverTrajectoryRosSubscriber::get_solver_trajectory,
            "Get the latest solver trajectory.\n\n"
            ":return: a list with the vector of time at the beginning of the\n"
            "interval, its durations, initial state, state's rate of change,\n"
@@ -123,10 +136,13 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            "parametrization.")
       .def("has_new_msg", &SolverTrajectoryRosSubscriber::has_new_msg);
 
-  py::class_<WholeBodyStateRosPublisher, std::unique_ptr<WholeBodyStateRosPublisher, py::nodelete>>(
+  py::class_<WholeBodyStateRosPublisher,
+             std::unique_ptr<WholeBodyStateRosPublisher, py::nodelete>>(
       m, "WholeBodyStateRosPublisher")
-      .def(py::init<pinocchio::Model &, const std::string &, const std::string &>(), py::arg("model"),
-           py::arg("topic") = "/crocoddyl/whole_body_state", py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"), py::arg("topic") = "/crocoddyl/whole_body_state",
+           py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("publish", &WholeBodyStateRosPublisher::publish,
            "Publish a whole-body state ROS message.\n\n"
@@ -138,13 +154,16 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            ":param pd: contact velocity\n"
            ":param f: contact force, type and status\n"
            ":param s: contact surface and friction coefficient",
-           py::arg("t"), py::arg("q"), py::arg("v"), py::arg("tau"), py::arg("p"), py::arg("pd"), py::arg("f"),
-           py::arg("s"));
+           py::arg("t"), py::arg("q"), py::arg("v"), py::arg("tau"),
+           py::arg("p"), py::arg("pd"), py::arg("f"), py::arg("s"));
 
-  py::class_<WholeBodyStateRosSubscriber, std::unique_ptr<WholeBodyStateRosSubscriber, py::nodelete>>(
+  py::class_<WholeBodyStateRosSubscriber,
+             std::unique_ptr<WholeBodyStateRosSubscriber, py::nodelete>>(
       m, "WholeBodyStateRosSubscriber")
-      .def(py::init<pinocchio::Model &, const std::string &, const std::string &>(), py::arg("model"),
-           py::arg("topic") = "/crocoddyl/whole_body_state", py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"), py::arg("topic") = "/crocoddyl/whole_body_state",
+           py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("get_state", &WholeBodyStateRosSubscriber::get_state,
            "Get the latest whole-body state.\n\n"
@@ -155,10 +174,14 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            "coefficient).")
       .def("has_new_msg", &WholeBodyStateRosSubscriber::has_new_msg);
 
-  py::class_<WholeBodyTrajectoryRosPublisher, std::unique_ptr<WholeBodyTrajectoryRosPublisher, py::nodelete>>(
+  py::class_<WholeBodyTrajectoryRosPublisher,
+             std::unique_ptr<WholeBodyTrajectoryRosPublisher, py::nodelete>>(
       m, "WholeBodyTrajectoryRosPublisher")
-      .def(py::init<pinocchio::Model &, const std::string &, const std::string &, int>(), py::arg("model"),
-           py::arg("topic") = "/crocoddyl/whole_body_trajectory", py::arg("frame") = "odom", py::arg("queue") = 10)
+      .def(py::init<pinocchio::Model &, const std::string &,
+                    const std::string &, int>(),
+           py::arg("model"),
+           py::arg("topic") = "/crocoddyl/whole_body_trajectory",
+           py::arg("frame") = "odom", py::arg("queue") = 10)
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("publish", &WholeBodyTrajectoryRosPublisher::publish,
            "Publish a whole-body trajectory ROS message.\n\n"
@@ -169,12 +192,17 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            ":param pds: list of contact velocities\n"
            ":param fs: list of contact forces, types and statuses\n"
            ":param ss: list of contact surfaces and friction coefficients",
-           py::arg("ts"), py::arg("xs"), py::arg("us"), py::arg("ps"), py::arg("pds"), py::arg("fs"), py::arg("ss"));
+           py::arg("ts"), py::arg("xs"), py::arg("us"), py::arg("ps"),
+           py::arg("pds"), py::arg("fs"), py::arg("ss"));
 
-  py::class_<WholeBodyTrajectoryRosSubscriber, std::unique_ptr<WholeBodyTrajectoryRosSubscriber, py::nodelete>>(
+  py::class_<WholeBodyTrajectoryRosSubscriber,
+             std::unique_ptr<WholeBodyTrajectoryRosSubscriber, py::nodelete>>(
       m, "WholeBodyTrajectoryRosSubscriber")
-      .def(py::init<pinocchio::Model &, const std::string &, const std::string &>(), py::arg("model"),
-           py::arg("topic") = "/crocoddyl/whole_body_trajectory", py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"),
+           py::arg("topic") = "/crocoddyl/whole_body_trajectory",
+           py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("get_trajectory", &WholeBodyTrajectoryRosSubscriber::get_trajectory,
            "Get the latest whole-body trajectory.\n\n"

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -151,6 +151,12 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
                     const std::string &>(),
            py::arg("model"), py::arg("topic") = "/crocoddyl/whole_body_state",
            py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::vector<std::string> &,
+                    const Eigen::VectorXd &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"), py::arg("locked_joints"), py::arg("qref"),
+           py::arg("topic") = "/crocoddyl/whole_body_state",
+           py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("publish", &WholeBodyStateRosPublisher::publish,
            "Publish a whole-body state ROS message.\n\n"
@@ -171,6 +177,12 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
       .def(py::init<pinocchio::Model &, const std::string &,
                     const std::string &>(),
            py::arg("model"), py::arg("topic") = "/crocoddyl/whole_body_state",
+           py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::vector<std::string> &,
+                    const Eigen::VectorXd &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"), py::arg("locked_joints"), py::arg("qref"),
+           py::arg("topic") = "/crocoddyl/whole_body_state",
            py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("get_state", &WholeBodyStateRosSubscriber::get_state,
@@ -222,7 +234,8 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
       .def("has_new_msg", &WholeBodyTrajectoryRosSubscriber::has_new_msg);
 
   m.def(
-      "fromReduced", &fromReduced_return<0, pinocchio::JointCollectionDefaultTpl>,
+      "fromReduced",
+      &fromReduced_return<0, pinocchio::JointCollectionDefaultTpl>,
       "Conversion from reduced position, velocity and effort to a full one.\n\n"
       ":param model: Pinocchio model\n"
       ":param reduced_model: Reduced Pinocchio model\n"

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -245,6 +245,11 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            "coefficients.")
       .def("has_new_msg", &WholeBodyTrajectoryRosSubscriber::has_new_msg);
 
+  m.def("getRootJointId", &getRootJointId<0, pinocchio::JointCollectionDefaultTpl>,
+           "Return the root joint id.\n\n"
+           ":param model: Pinocchio model\n"
+           ":return root joint id");
+
   m.def(
       "fromReduced",
       &fromReduced_return<0, pinocchio::JointCollectionDefaultTpl>,

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -1,3 +1,11 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2023-2023, Heriot-Watt University
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
 #include <pinocchio/fwd.hpp>
 
 #ifdef CROCODDYL_MSG_DISABLE_PYBIND11_WARNINGS

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -202,6 +202,12 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            py::arg("model"),
            py::arg("topic") = "/crocoddyl/whole_body_trajectory",
            py::arg("frame") = "odom", py::arg("queue") = 10)
+      .def(py::init<pinocchio::Model &, const std::vector<std::string> &,
+                    const Eigen::VectorXd &, const std::string &,
+                    const std::string &, int>(),
+           py::arg("model"), py::arg("locked_joints"), py::arg("qref"),
+           py::arg("topic") = "/crocoddyl/whole_body_state",
+           py::arg("frame") = "odom", py::arg("queue") = 10)
       .def(py::init<pinocchio::Model &>(), py::arg("model"))
       .def("publish", &WholeBodyTrajectoryRosPublisher::publish,
            "Publish a whole-body trajectory ROS message.\n\n"
@@ -221,6 +227,12 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
       .def(py::init<pinocchio::Model &, const std::string &,
                     const std::string &>(),
            py::arg("model"),
+           py::arg("topic") = "/crocoddyl/whole_body_trajectory",
+           py::arg("frame") = "odom")
+      .def(py::init<pinocchio::Model &, const std::vector<std::string> &,
+                    const Eigen::VectorXd &, const std::string &,
+                    const std::string &>(),
+           py::arg("model"), py::arg("locked_joints"), py::arg("qref"),
            py::arg("topic") = "/crocoddyl/whole_body_trajectory",
            py::arg("frame") = "odom")
       .def(py::init<pinocchio::Model &>(), py::arg("model"))

--- a/src/crocoddyl_ros.cpp
+++ b/src/crocoddyl_ros.cpp
@@ -220,4 +220,28 @@ PYBIND11_MODULE(crocoddyl_ros, m) {
            "friction\n"
            "coefficients.")
       .def("has_new_msg", &WholeBodyTrajectoryRosSubscriber::has_new_msg);
+
+  m.def(
+      "fromReduced", &fromReduced_return<0, pinocchio::JointCollectionDefaultTpl>,
+      "Conversion from reduced position, velocity and effort to a full one.\n\n"
+      ":param model: Pinocchio model\n"
+      ":param reduced_model: Reduced Pinocchio model\n"
+      ":param q: Reduced configuration vector (dimension: reduced_model.nq)\n"
+      ":param v: Reduced generalized velocity (dimension: reduced_model.nv)\n"
+      ":param tau: Reduced joint effort (dimension: reduced_model.nv - "
+      "nv_root)\n"
+      ":param qref: Reference configuration used in the reduced model\n"
+      ":param locked_joint_ids: Ids of the locked joints\n"
+      ":return q_full, v_full, tau_full");
+
+  m.def(
+      "toReduced", &toReduced_return<0, pinocchio::JointCollectionDefaultTpl>,
+      "Conversion to reduced position, velocity and effort from a full one.\n\n"
+      ":param model: Pinocchio model\n"
+      ":param reduced_model: Reduced Pinocchio model\n"
+      ":param q: Configuration vector (dimension: model.nq)\n"
+      ":param v: Generalized velocity (dimension: model.nv)\n"
+      ":param tau: Joint effort (dimension: model.nv - nv_root)\n"
+      ":return q_reduced, v_reduced, tau_reduced",
+      py::return_value_policy::take_ownership);
 }

--- a/unittest/test_solver_statistics.py
+++ b/unittest/test_solver_statistics.py
@@ -1,3 +1,11 @@
+###############################################################################
+# BSD 3-Clause License
+#
+# Copyright (C) 2023-2023, Heriot-Watt University
+# Copyright note valid unless otherwise stated in individual files.
+# All rights reserved.
+###############################################################################
+
 #!/usr/bin/env python
 import os
 import random

--- a/unittest/test_solver_statistics.py
+++ b/unittest/test_solver_statistics.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###############################################################################
 # BSD 3-Clause License
 #
@@ -6,7 +8,6 @@
 # All rights reserved.
 ###############################################################################
 
-#!/usr/bin/env python
 import os
 import random
 import time

--- a/unittest/test_solver_trajectory.py
+++ b/unittest/test_solver_trajectory.py
@@ -1,3 +1,11 @@
+###############################################################################
+# BSD 3-Clause License
+#
+# Copyright (C) 2023-2023, Heriot-Watt University
+# Copyright note valid unless otherwise stated in individual files.
+# All rights reserved.
+###############################################################################
+
 #!/usr/bin/env python
 import os
 import random

--- a/unittest/test_solver_trajectory.py
+++ b/unittest/test_solver_trajectory.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###############################################################################
 # BSD 3-Clause License
 #
@@ -6,7 +8,6 @@
 # All rights reserved.
 ###############################################################################
 
-#!/usr/bin/env python
 import os
 import random
 import time

--- a/unittest/test_whole_body_state.py
+++ b/unittest/test_whole_body_state.py
@@ -1,3 +1,11 @@
+###############################################################################
+# BSD 3-Clause License
+#
+# Copyright (C) 2023-2023, Heriot-Watt University
+# Copyright note valid unless otherwise stated in individual files.
+# All rights reserved.
+###############################################################################
+
 #!/usr/bin/env python
 import os
 import random

--- a/unittest/test_whole_body_state.py
+++ b/unittest/test_whole_body_state.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###############################################################################
 # BSD 3-Clause License
 #
@@ -6,7 +8,6 @@
 # All rights reserved.
 ###############################################################################
 
-#!/usr/bin/env python
 import os
 import random
 import time

--- a/unittest/test_whole_body_trajectory.py
+++ b/unittest/test_whole_body_trajectory.py
@@ -24,11 +24,11 @@ else:
     import rosunit
 
 from crocoddyl_ros import (
-    toReduced,
     ContactStatus,
     ContactType,
     WholeBodyTrajectoryRosPublisher,
     WholeBodyTrajectoryRosSubscriber,
+    toReduced,
 )
 
 
@@ -163,7 +163,9 @@ class TestWholeBodyTrajectory(unittest.TestCase):
         sub = WholeBodyTrajectoryRosSubscriber(
             model, locked_joints, qref, "whole_body_trajectory"
         )
-        pub = WholeBodyTrajectoryRosPublisher(model, locked_joints, qref, "whole_body_trajectory")
+        pub = WholeBodyTrajectoryRosPublisher(
+            model, locked_joints, qref, "whole_body_trajectory"
+        )
         time.sleep(1)
         # publish whole-body trajectory messages
         N = len(self.ts)
@@ -223,6 +225,7 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                     _S[1],
                     "Wrong contact friction coefficient at " + name + ", " + str(i),
                 )
+
 
 if __name__ == "__main__":
     if ROS_VERSION == 2:

--- a/unittest/test_whole_body_trajectory.py
+++ b/unittest/test_whole_body_trajectory.py
@@ -1,3 +1,11 @@
+###############################################################################
+# BSD 3-Clause License
+#
+# Copyright (C) 2023-2023, Heriot-Watt University
+# Copyright note valid unless otherwise stated in individual files.
+# All rights reserved.
+###############################################################################
+
 #!/usr/bin/env python
 import os
 import random

--- a/unittest/test_whole_body_trajectory.py
+++ b/unittest/test_whole_body_trajectory.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 ###############################################################################
 # BSD 3-Clause License
 #
@@ -6,7 +8,6 @@
 # All rights reserved.
 ###############################################################################
 
-#!/usr/bin/env python
 import os
 import random
 import time

--- a/unittest/test_whole_body_trajectory.py
+++ b/unittest/test_whole_body_trajectory.py
@@ -24,6 +24,7 @@ else:
     import rosunit
 
 from crocoddyl_ros import (
+    toReduced,
     ContactStatus,
     ContactType,
     WholeBodyTrajectoryRosPublisher,
@@ -32,32 +33,24 @@ from crocoddyl_ros import (
 
 
 class TestWholeBodyTrajectory(unittest.TestCase):
-    def test_bindings(self):
+    def setUp(self) -> None:
         if ROS_VERSION == 2:
             rclpy.init()
         else:
             rospy.init_node("crocoddyl_ros", anonymous=True)
-        model = pinocchio.buildSampleModelHumanoid()
-        sub = WholeBodyTrajectoryRosSubscriber(model)
-        pub = WholeBodyTrajectoryRosPublisher(model)
-        time.sleep(1)
-        # publish whole-body trajectory messages
+        # Create random trajectories
         h = random.uniform(0.1, 0.2)
-        ts = np.arange(0.0, 1.0, h).tolist()
-        N = len(ts)
-        xs, ps, pds, fs, ss = [], [], [], [], []
+        self.ts = np.arange(0.0, 1.0, h).tolist()
+        N = len(self.ts)
+        self.ps, self.pds, self.fs, self.ss = [], [], [], []
         for _ in range(N):
-            q = pinocchio.randomConfiguration(model)
-            q[:3] = np.random.rand(3)
-            v = np.random.rand(model.nv)
-            xs.append(np.hstack([q, v]))
-            ps.append(
+            self.ps.append(
                 {
                     "lleg_effector_body": pinocchio.SE3.Random(),
                     "rleg_effector_body": pinocchio.SE3.Random(),
                 }
             )
-            pds.append(
+            self.pds.append(
                 {
                     "lleg_effector_body": pinocchio.Motion.Random(),
                     "rleg_effector_body": pinocchio.Motion.Random(),
@@ -77,7 +70,7 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                 contact_status = ContactStatus.STICKING
             else:
                 contact_status = ContactStatus.SLIPPING
-            fs.append(
+            self.fs.append(
                 {
                     "lleg_effector_body": [
                         pinocchio.Force.Random(),
@@ -91,29 +84,43 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                     ],
                 }
             )
-            ss.append(
+            self.ss.append(
                 {
                     "lleg_effector_body": [np.random.rand(3), random.uniform(0, 1)],
                     "rleg_effector_body": [np.random.rand(3), random.uniform(0, 1)],
                 }
             )
+
+    def test_communication(self):
+        model = pinocchio.buildSampleModelHumanoid()
+        sub = WholeBodyTrajectoryRosSubscriber(model, "whole_body_trajectory")
+        pub = WholeBodyTrajectoryRosPublisher(model, "whole_body_trajectory")
+        time.sleep(1)
+        # publish whole-body trajectory messages
+        N = len(self.ts)
+        xs = []
+        for _ in range(N):
+            q = pinocchio.randomConfiguration(model)
+            q[:3] = np.random.rand(3)
+            v = np.random.rand(model.nv)
+            xs.append(np.hstack([q, v]))
         us = [np.random.rand(model.nv - 6) for _ in range(N)]
         while True:
-            pub.publish(ts, xs, us, ps, pds, fs, ss)
+            pub.publish(self.ts, xs, us, self.ps, self.pds, self.fs, self.ss)
             if sub.has_new_msg():
                 break
         # get whole-body trajectory
         _ts, _xs, _us, _ps, _pds, _fs, _ss = sub.get_trajectory()
         for i in range(N):
-            self.assertEqual(ts[i], _ts[i], "Wrong time interval at " + str(i))
+            self.assertEqual(self.ts[i], _ts[i], "Wrong time interval at " + str(i))
             self.assertTrue(
                 np.allclose(xs[i], _xs[i], atol=1e-9), "Wrong x at " + str(i)
             )
             self.assertTrue(np.allclose(us, _us, atol=1e-9), "Wrong u at " + str(i))
-            for name in ps[i]:
-                M, [_t, _R] = ps[i][name], _ps[i][name]
-                F, _F = fs[i][name], _fs[i][name]
-                S, _S = ss[i][name], _ss[i][name]
+            for name in self.ps[i]:
+                M, [_t, _R] = self.ps[i][name], _ps[i][name]
+                F, _F = self.fs[i][name], _fs[i][name]
+                S, _S = self.ss[i][name], _ss[i][name]
                 self.assertTrue(
                     np.allclose(M.translation, _t, atol=1e-9),
                     "Wrong contact translation at " + name + ", " + str(i),
@@ -123,7 +130,7 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                     "Wrong contact rotation at " + name + ", " + str(i),
                 )
                 self.assertTrue(
-                    np.allclose(pds[i][name].vector, _pds[i][name], atol=1e-9),
+                    np.allclose(self.pds[i][name].vector, _pds[i][name], atol=1e-9),
                     "Wrong contact velocity translation at " + name + ", " + str(i),
                 )
                 self.assertTrue(
@@ -146,6 +153,76 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                     "Wrong contact friction coefficient at " + name + ", " + str(i),
                 )
 
+    def test_communication_with_reduced_model(self):
+        model = pinocchio.buildSampleModelHumanoid()
+        locked_joints = ["larm_elbow_joint", "rarm_elbow_joint"]
+        qref = pinocchio.randomConfiguration(model)
+        reduced_model = pinocchio.buildReducedModel(
+            model, [model.getJointId(name) for name in locked_joints], qref
+        )
+        sub = WholeBodyTrajectoryRosSubscriber(
+            model, locked_joints, qref, "whole_body_trajectory"
+        )
+        pub = WholeBodyTrajectoryRosPublisher(model, locked_joints, qref, "whole_body_trajectory")
+        time.sleep(1)
+        # publish whole-body trajectory messages
+        N = len(self.ts)
+        xs, us = [], []
+        for _ in range(N):
+            q = pinocchio.randomConfiguration(model)
+            q[:3] = np.random.rand(3)
+            v = np.random.rand(model.nv)
+            tau = np.random.rand(model.nv - 6)
+            q, v, tau = toReduced(model, reduced_model, q, v, tau)
+            xs.append(np.hstack([q, v]))
+            us.append(tau)
+        while True:
+            pub.publish(self.ts, xs, us, self.ps, self.pds, self.fs, self.ss)
+            if sub.has_new_msg():
+                break
+        # get whole-body trajectory
+        _ts, _xs, _us, _ps, _pds, _fs, _ss = sub.get_trajectory()
+        for i in range(N):
+            self.assertEqual(self.ts[i], _ts[i], "Wrong time interval at " + str(i))
+            self.assertTrue(
+                np.allclose(xs[i], _xs[i], atol=1e-9), "Wrong x at " + str(i)
+            )
+            self.assertTrue(np.allclose(us, _us, atol=1e-9), "Wrong u at " + str(i))
+            for name in self.ps[i]:
+                M, [_t, _R] = self.ps[i][name], _ps[i][name]
+                F, _F = self.fs[i][name], _fs[i][name]
+                S, _S = self.ss[i][name], _ss[i][name]
+                self.assertTrue(
+                    np.allclose(M.translation, _t, atol=1e-9),
+                    "Wrong contact translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(M.rotation, _R, atol=1e-9),
+                    "Wrong contact rotation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(self.pds[i][name].vector, _pds[i][name], atol=1e-9),
+                    "Wrong contact velocity translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(F[0], _F[0], atol=1e-9),
+                    "Wrong contact wrench translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    F[1] == _F[1], "Wrong contact type at " + name + ", " + str(i)
+                )
+                self.assertTrue(
+                    F[2] == _F[2], "Wrong contact status at " + name + ", " + str(i)
+                )
+                self.assertTrue(
+                    np.allclose(S[0], _S[0], atol=1e-9),
+                    "Wrong contact surface translation at " + name + ", " + str(i),
+                )
+                self.assertEqual(
+                    S[1],
+                    _S[1],
+                    "Wrong contact friction coefficient at " + name + ", " + str(i),
+                )
 
 if __name__ == "__main__":
     if ROS_VERSION == 2:


### PR DESCRIPTION
This PR introduces the notion of locked joints of rigid body systems in publishers and subscribers. With the proposed approach, our subscribers or publishers are able to receive and send reduced states and controls.

The feature enables us to write
  1. MPC subscribers or
  2. simulators publishers
that consider a part of the joints.

Additionally, this PR simplifies the code of each publisher and subscriber and includes extra unit tests to check the proposed new feature.

Fyi @james-p-foster and @Sergim96 -- I will work on points 1 (caracal) and 2 (pybullet-csuite). @james-p-foster -- I need your help translating this strategy into the ilmc-msgs package.