### PR TITLE
Bugfix in init functions for empty locked joints

### DIFF
--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -150,17 +150,15 @@ private:
 
     if (locked_joints.size() != 0) {
       // Check the size of the reference configuration
+      if (qref_.size() != model_.nq) {
 #ifdef ROS2
-      if (qref_.size() != model_.nq) {
         RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
-      }
 #else
-      if (qref_.size() != model_.nq) {
         ROS_ERROR_STREAM(
             "Invalid argument: qref has wrong dimension (it should be "
             << std::to_string(model_.nq) << ")");
-      }
 #endif
+      }
       // Build the reduced model
       for (std::string name : locked_joints) {
         if (model_.existJointName(name)) {

--- a/include/crocoddyl_msgs/whole_body_state_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_state_publisher.h
@@ -179,6 +179,8 @@ private:
       qfull_ = Eigen::VectorXd::Zero(model_.nq);
       vfull_ = Eigen::VectorXd::Zero(model_.nv);
       ufull_ = Eigen::VectorXd::Zero(model_.nv - nv_root);
+    } else {
+      is_reduced_model_ = false;
     }
   }
 };

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -225,17 +225,15 @@ private:
     const std::size_t nv_root = model_.joints[root_joint_id].nv();
     if (locked_joints.size() != 0) {
       // Check the size of the reference configuration
+      if (qref_.size() != model_.nq) {
 #ifdef ROS2
-      if (qref_.size() != model_.nq) {
         RCLCPP_ERROR_STREAM(node_->get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
-      }
 #else
-      if (qref_.size() != model_.nq) {
         ROS_ERROR_STREAM(
             "Invalid argument: qref has wrong dimension (it should be "
             << std::to_string(model_.nq) << ")");
-      }
 #endif
+      }
       // Build the reduced model
       for (std::string name : locked_joints) {
         if (model_.existJointName(name)) {

--- a/include/crocoddyl_msgs/whole_body_state_subscriber.h
+++ b/include/crocoddyl_msgs/whole_body_state_subscriber.h
@@ -256,6 +256,7 @@ private:
       ufull_ = Eigen::VectorXd::Zero(model_.nv - nv_root);
     } else {
       tau_ = Eigen::VectorXd::Zero(model_.nv - nv_root);
+      is_reduced_model_ = false;
     }
     q_.setZero();
     v_.setZero();

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -203,17 +203,15 @@ private:
 
     if (locked_joints.size() != 0) {
       // Check the size of the reference configuration
+      if (qref_.size() != model_.nq) {
 #ifdef ROS2
-      if (qref_.size() != model_.nq) {
         RCLCPP_ERROR_STREAM(node_.get_logger(), "Invalid argument: qref has wrong dimension (it should be " << std::to_string(model_.nq) << ")");
-      }
 #else
-      if (qref_.size() != model_.nq) {
         ROS_ERROR_STREAM(
             "Invalid argument: qref has wrong dimension (it should be "
             << std::to_string(model_.nq) << ")");
-      }
 #endif
+      }
       // Build the reduced model
       for (std::string name : locked_joints) {
         if (model_.existJointName(name)) {

--- a/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
+++ b/include/crocoddyl_msgs/whole_body_trajectory_publisher.h
@@ -233,6 +233,8 @@ private:
       qfull_ = Eigen::VectorXd::Zero(model_.nq);
       vfull_ = Eigen::VectorXd::Zero(model_.nv);
       ufull_ = Eigen::VectorXd::Zero(model_.nv - nv_root);
+    } else {
+      is_reduced_model_ = false;
     }
   }
 };

--- a/unittest/test_whole_body_state.py
+++ b/unittest/test_whole_body_state.py
@@ -187,6 +187,63 @@ class TestWholeBodyState(unittest.TestCase):
                 S[1], _S[1], "Wrong contact friction coefficient at " + name
             )
 
+    def test_communication_with_non_locked_joints(self):
+        model = pinocchio.buildSampleModelHumanoid()
+        locked_joints = []
+        qref = pinocchio.randomConfiguration(model)
+        reduced_model = pinocchio.buildReducedModel(
+            model, [model.getJointId(name) for name in locked_joints], qref
+        )
+        sub = WholeBodyStateRosSubscriber(
+            model, locked_joints, qref, "whole_body_state"
+        )
+        pub = WholeBodyStateRosPublisher(model, locked_joints, qref, "whole_body_state")
+        time.sleep(1)
+        # publish whole-body state messages
+        q = pinocchio.randomConfiguration(model)
+        q[:3] = np.random.rand(3)
+        v = np.random.rand(model.nv)
+        tau = np.random.rand(model.nv - 6)
+        q, v, tau = toReduced(model, reduced_model, q, v, tau)
+        while True:
+            pub.publish(self.t, q, v, tau, self.p, self.pd, self.f, self.s)
+            if sub.has_new_msg():
+                break
+        # get whole-body state
+        _t, _q, _v, _tau, _p, _pd, _f, _s = sub.get_state()
+        self.assertEqual(self.t, _t, "Wrong time interval")
+        self.assertTrue(np.allclose(q, _q, atol=1e-9), "Wrong q")
+        self.assertTrue(np.allclose(v, _v, atol=1e-9), "Wrong v")
+        self.assertTrue(np.allclose(tau, _tau, atol=1e-9), "Wrong tau")
+        for name in self.p:
+            M, [_t, _R] = self.p[name], _p[name]
+            F, _F = self.f[name], _f[name]
+            S, _S = self.s[name], _s[name]
+            self.assertTrue(
+                np.allclose(M.translation, _t, atol=1e-9),
+                "Wrong contact translation at " + name,
+            )
+            self.assertTrue(
+                np.allclose(M.rotation, _R, atol=1e-9),
+                "Wrong contact rotation at " + name,
+            )
+            self.assertTrue(
+                np.allclose(self.pd[name].vector, _pd[name], atol=1e-9),
+                "Wrong contact velocity translation at " + name,
+            )
+            self.assertTrue(
+                np.allclose(F[0], _F[0], atol=1e-9),
+                "Wrong contact wrench translation at " + name,
+            )
+            self.assertTrue(F[1] == _F[1], "Wrong contact type at " + name)
+            self.assertTrue(F[2] == _F[2], "Wrong contact status at " + name)
+            self.assertTrue(
+                np.allclose(S[0], _S[0], atol=1e-9),
+                "Wrong contact surface translation at " + name,
+            )
+            self.assertEqual(
+                S[1], _S[1], "Wrong contact friction coefficient at " + name
+            )
 
 if __name__ == "__main__":
     if ROS_VERSION == 2:

--- a/unittest/test_whole_body_trajectory.py
+++ b/unittest/test_whole_body_trajectory.py
@@ -226,6 +226,79 @@ class TestWholeBodyTrajectory(unittest.TestCase):
                     "Wrong contact friction coefficient at " + name + ", " + str(i),
                 )
 
+    def test_communication_with_non_locked_joints(self):
+        model = pinocchio.buildSampleModelHumanoid()
+        locked_joints = ["larm_elbow_joint", "rarm_elbow_joint"]
+        qref = pinocchio.randomConfiguration(model)
+        reduced_model = pinocchio.buildReducedModel(
+            model, [model.getJointId(name) for name in locked_joints], qref
+        )
+        sub = WholeBodyTrajectoryRosSubscriber(
+            model, locked_joints, qref, "whole_body_trajectory"
+        )
+        pub = WholeBodyTrajectoryRosPublisher(
+            model, locked_joints, qref, "whole_body_trajectory"
+        )
+        time.sleep(1)
+        # publish whole-body trajectory messages
+        N = len(self.ts)
+        xs, us = [], []
+        for _ in range(N):
+            q = pinocchio.randomConfiguration(model)
+            q[:3] = np.random.rand(3)
+            v = np.random.rand(model.nv)
+            tau = np.random.rand(model.nv - 6)
+            q, v, tau = toReduced(model, reduced_model, q, v, tau)
+            xs.append(np.hstack([q, v]))
+            us.append(tau)
+        while True:
+            pub.publish(self.ts, xs, us, self.ps, self.pds, self.fs, self.ss)
+            if sub.has_new_msg():
+                break
+        # get whole-body trajectory
+        _ts, _xs, _us, _ps, _pds, _fs, _ss = sub.get_trajectory()
+        for i in range(N):
+            self.assertEqual(self.ts[i], _ts[i], "Wrong time interval at " + str(i))
+            self.assertTrue(
+                np.allclose(xs[i], _xs[i], atol=1e-9), "Wrong x at " + str(i)
+            )
+            self.assertTrue(np.allclose(us, _us, atol=1e-9), "Wrong u at " + str(i))
+            for name in self.ps[i]:
+                M, [_t, _R] = self.ps[i][name], _ps[i][name]
+                F, _F = self.fs[i][name], _fs[i][name]
+                S, _S = self.ss[i][name], _ss[i][name]
+                self.assertTrue(
+                    np.allclose(M.translation, _t, atol=1e-9),
+                    "Wrong contact translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(M.rotation, _R, atol=1e-9),
+                    "Wrong contact rotation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(self.pds[i][name].vector, _pds[i][name], atol=1e-9),
+                    "Wrong contact velocity translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    np.allclose(F[0], _F[0], atol=1e-9),
+                    "Wrong contact wrench translation at " + name + ", " + str(i),
+                )
+                self.assertTrue(
+                    F[1] == _F[1], "Wrong contact type at " + name + ", " + str(i)
+                )
+                self.assertTrue(
+                    F[2] == _F[2], "Wrong contact status at " + name + ", " + str(i)
+                )
+                self.assertTrue(
+                    np.allclose(S[0], _S[0], atol=1e-9),
+                    "Wrong contact surface translation at " + name + ", " + str(i),
+                )
+                self.assertEqual(
+                    S[1],
+                    _S[1],
+                    "Wrong contact friction coefficient at " + name + ", " + str(i),
+                )
+
 
 if __name__ == "__main__":
     if ROS_VERSION == 2:


### PR DESCRIPTION
This PR fixes a bug in the init function when we pass an empty vector of locked joints. This issue was happening in publishers and subscribers of whole-body states and trajectories. Additionally, it extends our unit test by checking this condition.